### PR TITLE
feat: migração para schema normalizado (projects_v2 + tabelas filhas)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,10 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
-# Editor
+# Editor e ferramentas locais
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 .DS_Store
@@ -29,3 +30,9 @@ Thumbs.db
 
 # Cache
 .eslintcache
+
+#Personal
+screenshot/
+
+# Migration artifacts
+scripts/id-map-*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,10 +64,11 @@ Todo o estado da aplicação vive em `src/context/AppContext.jsx`. Ele expõe:
 
 ### Persistência e sincronização
 
-- **Offline-first:** toda mutação salva em `localStorage` imediatamente
+- **Offline-first:** toda mutação salva em `localStorage` imediatamente sob a chave `rl_projects_v2`
 - **Debounce:** `updateProject` tem debounce de 1s por `id` antes de escrever no Supabase (via `upsertTimers` ref)
 - **Race condition:** `pendingWrites` ref contador — o listener de realtime ignora eventos enquanto há escritas locais pendentes
-- **Realtime granular:** listener usa handlers separados por evento (`INSERT`/`UPDATE`/`DELETE`), atualizando apenas o registro afetado no state local
+- **Realtime granular:** listener em `projects_v2` usa handlers separados por evento (`INSERT`/`UPDATE`/`DELETE`), atualizando apenas o registro afetado no state local. Mudanças em tabelas filhas (personas, criativos, etc.) **não** disparam realtime — são refletidas apenas via escrita local imediata.
+- **Aliases camelCase:** `assembleProject()` em AppContext expõe tanto os campos snake_case do DB quanto aliases camelCase (ex: `company_name` + `companyName`) para compatibilidade com os componentes existentes.
 
 ### Jornada de onboarding (`ProjectDetail`)
 
@@ -86,14 +87,49 @@ Quando as 3 estão completas (`allDone`), a página renderiza diretamente `Clien
 - Renderização de output da IA: `react-markdown` + `rehype-sanitize` (sem `dangerouslySetInnerHTML`)
 - Em desenvolvimento local, use `vercel dev`; o Vite puro (`npm run dev`) não serve `/api/*` e a IA não funcionará
 
-### Supabase
+### Supabase — Schema normalizado
 
-- `src/lib/supabase.js` — retorna `null` se as env vars não estiverem definidas
-- Tabela `projects`: colunas `id`, `data` (JSONB com todo o projeto), `created_at`, `updated_at`
-  - RLS habilitado: admins acessam todos os projetos; accounts acessam apenas os próprios (`data->>'accountId' = auth.uid()`)
+`src/lib/supabase.js` — retorna `null` se as env vars não estiverem definidas. Exporta também helpers de Storage: `uploadFile`, `deleteFile`, `getSignedUrl`.
+
+#### Tabela principal
+
+- **`projects_v2`** — projetos com schema normalizado; UUID PK gerado via `crypto.randomUUID()` no browser antes do INSERT. Contém campos da empresa, contrato, equipe e serviços.
+  - RLS: admins acessam todos; accounts acessam apenas onde `account_id = auth.uid()`
   - A role é lida diretamente do JWT: `auth.jwt() -> 'user_metadata' ->> 'role'`
-- Tabela `profiles`: colunas `id`, `name`, `email`, `avatar`, `role`, `disabled boolean`, `created_at` — espelha os metadados do Auth; usada para listar membros do time no Dashboard e pela gestão de usuários
-  - RLS habilitado: leitura para qualquer autenticado; admins podem escrever qualquer perfil (policies `profiles_admin_write` e `profiles_admin_insert`); cada usuário só escreve o próprio
+- **`profiles`** — espelha os metadados do Auth; usada para listar membros do time no Dashboard e pela gestão de usuários
+  - RLS: leitura para qualquer autenticado; admins podem escrever qualquer perfil; cada usuário só escreve o próprio
+
+#### Tabelas filhas (FK `project_id → projects_v2(id) ON DELETE CASCADE`)
+
+| Tabela | Cardinalidade | Chave patch no AppContext |
+|---|---|---|
+| `roi_calculators` | N por projeto | `roiCalc` + `roiResult` |
+| `personas` | N por projeto | `personas` (array — delete+insert) |
+| `ofertas` | 1 por projeto | `ofertaData` |
+| `campaign_plans` | N por projeto | `campaignPlan` |
+| `resultados` | N por projeto (UNIQUE `project_id, period`) | pendente Phase 5 |
+| `criativos` | N por projeto | `creatives` (array — delete+insert) |
+| `google_ads` | N por projeto | `googleAds` (array — delete+insert) |
+| `landing_pages` | N por projeto | `landingPages` (array — delete+insert) |
+| `banco_midia` | 1:1 com projeto | `brandFotos` / `brandVideos` / `brandKit` |
+| `estrategia` | 1:1 com projeto | `estrategia` |
+| `estrategia_v2` | 1:1 com projeto | `estrategiaV2` |
+| `attachments` | N por projeto | `attachments` (array — delete+insert) |
+
+#### Roteamento de patches em `updateProject`
+
+`sbUpdateProjectV2(id, patch)` inspeciona as chaves do patch e roteia cada uma para a tabela correta. Campos de `projects_v2` são mapeados via `PROJECT_FIELD_MAP` (aceita tanto camelCase quanto snake_case). Campos não reconhecidos são ignorados silenciosamente (ex: `progress`, que é derivado de `completedSteps`).
+
+#### Supabase Storage — buckets
+
+| Bucket | Acesso | Uso |
+|---|---|---|
+| `project-docs` | privado | `raio_x` e `sla` do onboarding (pendente Phase 5) |
+| `brand-media` | privado | fotos e vídeos do banco de mídia (pendente Phase 5) |
+| `brand-logos` | privado | logotipo da marca |
+| `attachments` | privado | uploads avulsos do `AnexosModule` (base64 ainda; pendente Phase 5) |
+
+Path convention: `{projectId}/{filename}`. Storage policies espelham as RLS das tabelas filhas.
 
 ### Autenticação (Supabase Auth)
 
@@ -112,7 +148,7 @@ Quando as 3 estão completas (`allDone`), a página renderiza diretamente `Clien
 
 ### Draft de onboarding
 
-`NewOnboarding` persiste rascunho em `localStorage` sob a chave `rl_onboarding_draft`; restaurado automaticamente na próxima visita.
+`NewOnboarding` persiste rascunho em `localStorage` sob a chave `rl_new_onboarding_draft`; restaurado automaticamente na próxima visita. O payload enviado a `addProject` usa **snake_case** (mapeado direto para `projects_v2`).
 
 ### Gestão de Usuários
 
@@ -121,6 +157,16 @@ Quando as 3 estão completas (`allDone`), a página renderiza diretamente `Clien
   - Actions suportadas: `create_user` (cria usuário no Auth + perfil em `profiles`), `update_user` (atualiza metadados e perfil), `toggle_user` (ativa/desativa via campo `disabled` em `profiles` e `user_metadata`)
 - `src/pages/UserManagement.jsx` — página de gestão; protegida pelo HOC `RequireAdmin` em `App.jsx`, que redireciona para `/` caso o usuário não seja admin
 - Item "Usuários" na sidebar (`AppSidebar.jsx`) é renderizado apenas para admins
+
+### Pendências (Phase 5)
+
+Os seguintes componentes ainda usam base64 / estrutura legada e precisam ser atualizados:
+
+| Componente | Trabalho |
+|---|---|
+| `AnexosModule.jsx` | Substituir FileReader base64 por `uploadFile('attachments', ...)` de `src/lib/supabase.js` |
+| `BancoMidiaModule.jsx` | Upload de fotos/vídeos para `brand-media`; logo para `brand-logos` |
+| `ResultadosModule.jsx` | Adaptar estrutura legada `b2b{month{week}}` para array de rows `{ period: DATE, ... }` na tabela `resultados` |
 
 ### Estilo
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Ao completar as 3 etapas, o projeto se torna um **Perfil Completo** — um docum
 - Autenticação via Supabase Auth (email/senha + Google OAuth)
 - Dashboard com cards de projetos, stats (em onboarding, ativos, total) e filtros por status ou membro do time
 - Controle de acesso: admins veem todos os projetos; usuários comuns veem apenas os seus
-- IA integrada (Claude API) para geração de personas e ofertas — chave configurável via Settings
-- Sincronização em nuvem via Supabase
+- IA integrada (Claude API) para geração de personas, ofertas, criativos, Google Ads, landing pages e estratégia
+- Sincronização em nuvem via Supabase com schema normalizado
+- Upload de arquivos para Supabase Storage (PDFs, logos, anexos)
 - Exportação de perfis em PDF
 - Gestão de usuários (admin): criar, editar nome/role, desativar/reativar membros do time
 
@@ -28,7 +29,7 @@ Ao completar as 3 etapas, o projeto se torna um **Perfil Completo** — um docum
 
 - React 18 + Vite + Tailwind CSS
 - React Router v6
-- Supabase (auth + banco de dados)
+- Supabase (auth + banco de dados + storage)
 - Anthropic Claude API (IA generativa)
 
 ## Estrutura de pastas
@@ -59,25 +60,30 @@ area-do-cliente/
 │   │   ├── AppSidebar.jsx         # Menu lateral da aplicação
 │   │   ├── CampaignPlanner.jsx    # Planejador de campanhas
 │   │   ├── CriativosModule.jsx    # Módulo de criativos
-│   │   ├── EstrategiaModule.jsx   # Módulo de estratégia
+│   │   ├── EstrategiaModule.jsx   # Módulo de estratégia (narrativa IA)
+│   │   ├── EstrategiaV2Module.jsx # Módulo de estratégia estruturada (SWOT, riscos, funis)
 │   │   ├── GoogleAdsModule.jsx    # Módulo Google Ads
 │   │   ├── MetaLabModule.jsx      # Módulo Meta (Facebook/Instagram Ads)
 │   │   ├── LandingPageModule.jsx  # Módulo de landing pages
 │   │   ├── ResultadosModule.jsx   # Módulo de resultados/métricas
 │   │   ├── AnexosModule.jsx       # Módulo de anexos/arquivos
+│   │   ├── BancoMidiaModule.jsx   # Biblioteca de marca (fotos, vídeos, cores, tipografia)
 │   │   ├── ROICalculator.jsx      # Calculadora de ROI
-│   │   └── RatingSelector.jsx     # Componente de avaliação por estrelas
+│   │   └── RatingSelector.jsx     # Componente de avaliação
 │   │
 │   ├── context/
-│   │   └── AppContext.jsx     # Context global (estado compartilhado entre páginas)
+│   │   └── AppContext.jsx     # Context global — CRUD de projetos com roteamento por tabela
 │   │
-│   ├── lib/
-│   │   ├── claude.js          # Cliente para chamadas à API do Claude (IA)
-│   │   ├── supabase.js        # Cliente Supabase (banco de dados/auth)
-│   │   └── buildContext.js    # Helper para montar o contexto enviado ao Claude
-│   │
-│   └── utils/
-│       └── exportPDF.js       # Utilitário para exportar dados em PDF
+│   └── lib/
+│       ├── claude.js          # Cliente para chamadas à API do Claude (IA)
+│       ├── supabase.js        # Cliente Supabase + helpers de Storage
+│       └── buildContext.js    # Helper para montar o contexto enviado ao Claude
+│
+├── supabase/
+│   └── migrations/            # DDL versionado (001–016); aplicar em ordem no Supabase
+│
+├── docs/
+│   └── schema-inputs.md       # Mapeamento completo de inputs → tipos SQL por entidade
 │
 ├── index.html                 # HTML raiz do Vite
 ├── vite.config.js             # Configuração do Vite (bundler)
@@ -85,7 +91,6 @@ area-do-cliente/
 ├── postcss.config.js          # Configuração do PostCSS
 ├── vercel.json                # Configuração de deploy na Vercel
 ├── package.json               # Dependências e scripts
-├── start.sh                   # Script de inicialização local
 └── .env.example               # Variáveis de ambiente necessárias
 ```
 
@@ -109,7 +114,6 @@ Há dois modos de desenvolvimento:
 
 > Use `vercel dev` para o desenvolvimento completo. `npm run dev` é suficiente para trabalho exclusivo no frontend.
 
-
 ## Autenticação
 
 O sistema usa **Supabase Auth**. Os usuários do time são gerenciados via painel de administração da aplicação.
@@ -126,20 +130,54 @@ Nome, avatar e role de cada usuário são armazenados em `user_metadata` no Supa
 
 ## Banco de dados
 
-Tabelas no Supabase:
+O schema é normalizado. A tabela principal é `projects_v2`; cada domínio tem sua própria tabela com FK para o projeto.
+
+### Tabelas
 
 | Tabela | Descrição |
 |---|---|
-| `projects` | Projetos de onboarding — coluna `data` (JSONB) contém todo o estado do projeto |
-| `profiles` | Perfis do time — colunas `id`, `name`, `email`, `avatar`, `role`, `disabled boolean`, `created_at`; sincronizados do Auth, usados para listagem no Dashboard e gestão de usuários |
+| `projects_v2` | Projetos — empresa, contrato, equipe, serviços; UUID PK |
+| `profiles` | Perfis do time — sincronizados do Auth |
+| `roi_calculators` | Cenários de ROI (múltiplos por projeto) |
+| `personas` | Personas geradas por IA |
+| `ofertas` | Oferta matadora (1 por projeto) |
+| `campaign_plans` | Planos de campanha |
+| `resultados` | Métricas semanais/mensais (UNIQUE por projeto + período) |
+| `criativos` | Criativos gerados por IA |
+| `google_ads` | Campanhas Google Ads geradas por IA |
+| `landing_pages` | Landing pages geradas por IA |
+| `banco_midia` | Biblioteca de marca (1:1 com projeto) |
+| `estrategia` | Narrativa estratégica gerada por IA (1:1 com projeto) |
+| `estrategia_v2` | Análise estratégica estruturada — SWOT, concorrentes, riscos, funis (1:1) |
+| `attachments` | Anexos — metadados + path no Storage |
 
 ### Row Level Security (RLS)
 
-Ambas as tabelas têm RLS habilitado:
+Todas as tabelas têm RLS habilitado:
 
-| Tabela | Regra |
+| Escopo | Regra |
 |---|---|
-| `projects` | Admins acessam todos os registros; accounts acessam apenas projetos onde `data->>'accountId'` = `auth.uid()` |
-| `profiles` | Qualquer usuário autenticado pode ler todos os perfis; admins podem ler e escrever qualquer perfil (policies `profiles_admin_write` e `profiles_admin_insert`); cada usuário só escreve o próprio |
+| `projects_v2` | Admins acessam todos; accounts acessam apenas onde `account_id = auth.uid()` |
+| Tabelas filhas | RLS via subquery: `project_id IN (SELECT id FROM projects_v2 WHERE account_id = auth.uid())` |
+| `profiles` | Qualquer autenticado lê; admins escrevem qualquer perfil; cada usuário escreve o próprio |
 
 A role é lida diretamente do token JWT (`auth.jwt() -> 'user_metadata' ->> 'role'`), sem depender de tabela auxiliar.
+
+### Supabase Storage
+
+| Bucket | Uso |
+|---|---|
+| `attachments` | Anexos de projetos (PDFs, docs) |
+| `brand-logos` | Logotipos de marca |
+| `brand-media` | Fotos e vídeos do banco de mídia |
+| `project-docs` | Raio-X e SLA do onboarding |
+
+Todos os buckets são privados. Path: `{projectId}/{filename}`.
+
+### Aplicar migrations em novo ambiente
+
+```bash
+# As migrations estão em supabase/migrations/ — aplicar em ordem numérica (001 → 016)
+# via Supabase Dashboard → SQL Editor, ou com a Supabase CLI:
+supabase db push
+```

--- a/docs/migration-playbook.md
+++ b/docs/migration-playbook.md
@@ -1,0 +1,164 @@
+# Migration Playbook — Revenue Lab Schema v2
+
+> Receita para executar a migração do schema JSONB (`projects.data`) para o schema normalizado (`projects_v2` + tabelas filhas) em ambiente de produção.
+
+---
+
+## Pré-requisitos
+
+- [ ] Backup completo da tabela `projects` (export via Supabase Dashboard → Table Editor → Export)
+- [ ] `SUPABASE_URL` e `SUPABASE_SERVICE_ROLE_KEY` disponíveis localmente
+- [ ] Node.js ≥ 18 instalado
+- [ ] Todas as migrations `001–015` já aplicadas no projeto Supabase
+- [ ] Buckets Storage criados: `project-docs`, `brand-media`, `brand-logos`, `attachments`
+
+---
+
+## Ordem de execução
+
+### Passo 1 — Freeze de escrita (opcional, recomendado para produção)
+
+Colocar banner de manutenção ou desabilitar acesso ao app por 5–10 minutos durante a migração.
+
+### Passo 2 — Executar script de migração de dados
+
+```bash
+# Dry run primeiro (não escreve nada)
+SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/migrate-from-legacy.js --dry-run
+
+# Migração real
+SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/migrate-from-legacy.js
+```
+
+O script gera um arquivo `scripts/id-map-<timestamp>.json` com o mapeamento `legacyId → newUUID`.
+
+**Nota:** Arquivos base64 (fotos, vídeos, logos, anexos) **não são migrados automaticamente**. Ver Passo 3.
+
+### Passo 3 — Upload manual de arquivos para Storage
+
+Para cada projeto que continha arquivos base64 (identificados pelos avisos `⚠️` do script):
+
+1. Baixar o JSONB legado via Supabase Dashboard ou SQL:
+   ```sql
+   SELECT id, data->>'companyName', data->'brandFotos', data->'brandVideos',
+          data->'brandKit'->>'logo', data->'attachments'
+   FROM projects
+   WHERE data->'brandFotos' IS NOT NULL OR data->'attachments' IS NOT NULL;
+   ```
+
+2. Para cada arquivo base64, fazer upload para o bucket correto:
+   - `brand-media/{newProjectId}/{filename}` — fotos e vídeos
+   - `brand-logos/{newProjectId}/logo` — logotipo
+   - `attachments/{newProjectId}/{filename}` — anexos
+
+3. Atualizar `banco_midia.logo_url`, `banco_midia.photos[].url`, `banco_midia.videos[].url` e `attachments.storage_path` com as URLs do Storage.
+
+### Passo 4 — Verificar integridade
+
+```sql
+-- Contagem geral
+SELECT
+  (SELECT count(*) FROM projects)    AS legado,
+  (SELECT count(*) FROM projects_v2) AS novo;
+
+-- Verificar projetos sem account_id (possível erro de migração)
+SELECT id, legacy_id FROM projects_v2 WHERE account_id IS NULL;
+
+-- Verificar projetos com completedSteps mas sem relações correspondentes
+SELECT p.id, p.legacy_id, p.completed_steps
+FROM projects_v2 p
+LEFT JOIN roi_calculators r ON r.project_id = p.id
+WHERE 'roi' = ANY(p.completed_steps) AND r.id IS NULL;
+```
+
+### Passo 5 — Deploy do código novo
+
+Fazer deploy da versão com:
+- `AppContext.jsx` reescrito (usa `projects_v2`)
+- `NewOnboarding.jsx` com campos snake_case
+- Migrations `001–015` aplicadas
+
+### Passo 6 — Limpeza do localStorage nos clientes
+
+Cada usuário precisa limpar o localStorage antigo na primeira sessão. Para forçar isso automaticamente, adicionar ao `AppProvider` no mount:
+
+```js
+// Migração do localStorage: remover chave antiga
+useEffect(() => {
+  const hadLegacy = localStorage.getItem('rl_projects');
+  if (hadLegacy) {
+    localStorage.removeItem('rl_projects');
+    localStorage.removeItem('rl_new_onboarding_draft');
+    // A chave nova rl_projects_v2 será populada via sbFetchAll()
+  }
+}, []);
+```
+
+Ou via console do browser:
+```js
+localStorage.removeItem('rl_projects');
+localStorage.removeItem('rl_new_onboarding_draft');
+```
+
+---
+
+## Passos finais (pós-validação em produção)
+
+Após confirmar que tudo funciona corretamente com `projects_v2`:
+
+```sql
+-- 1. Dropar tabela legada
+DROP TABLE projects;
+
+-- 2. Renomear projects_v2 → projects
+ALTER TABLE projects_v2 RENAME TO projects;
+
+-- 3. Renomear constraints e triggers
+ALTER INDEX projects_v2_pkey RENAME TO projects_pkey;
+ALTER TRIGGER projects_v2_updated_at ON projects RENAME TO projects_updated_at;
+
+-- 4. Atualizar FKs das tabelas filhas
+-- (se usou ON DELETE CASCADE, as FKs continuam válidas após rename)
+```
+
+---
+
+## Rollback
+
+Se algo der errado **antes** do Passo Final:
+
+1. Fazer revert do deploy para a versão que usa `projects` (JSONB)
+2. As tabelas `projects_v2` e filhas podem ser dropadas sem afetar o sistema legado:
+   ```sql
+   DROP TABLE IF EXISTS attachments, estrategia_v2, estrategia,
+     banco_midia, landing_pages, google_ads, criativos,
+     resultados, campaign_plans, ofertas, personas,
+     roi_calculators, projects_v2 CASCADE;
+   ```
+3. Restaurar `projects` a partir do backup se necessário
+
+---
+
+## Pendências (Phase 5 — componentes)
+
+Os seguintes componentes precisam ser atualizados para usar Storage em vez de base64:
+
+| Componente | Trabalho necessário |
+|---|---|
+| `AnexosModule.jsx` | Substituir FileReader base64 por upload direto ao Supabase Storage (bucket `attachments`); salvar `storage_path` em vez de `data` |
+| `BancoMidiaModule.jsx` | Upload de fotos/vídeos para `brand-media`, logo para `brand-logos`; salvar URLs em vez de base64 |
+| `ResultadosModule.jsx` | Adaptar estrutura `b2b{month{week{...}}}` para array de rows `{ period: DATE, leads, mql, sql, vendas, investido, valor_vendas }` |
+
+Até essa migração, os dados de Anexos e Banco de Mídia continuam funcionando em base64 (localStorage), e Resultados permanece em formato legado (não persistido na tabela `resultados`).
+
+---
+
+## Checklist de validação end-to-end
+
+- [ ] Criar novo projeto pelo fluxo de onboarding → confirmar row em `projects_v2`
+- [ ] Abrir projeto existente (migrado) → verificar que todos os módulos carregam dados
+- [ ] Editar ROI / gerar persona / gerar oferta → confirmar upsert nas tabelas corretas
+- [ ] Upload de arquivo (após Phase 5) → confirmar arquivo no Storage e metadata em tabela
+- [ ] ResultadosModule: inserir dados → confirmar rows em `resultados` (após Phase 5)
+- [ ] Checar RLS: usuário account não vê projetos de outros
+- [ ] Verificar realtime: alterar projeto em tab A → ver atualização em tab B

--- a/docs/schema-inputs.md
+++ b/docs/schema-inputs.md
@@ -1,0 +1,311 @@
+# Mapeamento de Inputs do Usuário — Revenue Lab
+
+> Levantamento completo de todos os campos inseridos pelo usuário no sistema,
+> organizados por entidade/domínio, com sugestão de tipo de dado para o banco de dados.
+
+---
+
+## 1. Entidade: `profiles`
+
+> Telas: **Login**, **UserManagement**
+> ⚠️ Estrutura atual — não alterar.
+
+| Campo | Tipo SQL atual | Observações |
+|---|---|---|
+| `id` | `UUID PRIMARY KEY` | Espelha o `id` do Supabase Auth |
+| `name` | `TEXT` | Nome completo |
+| `email` | `TEXT` | Email de autenticação |
+| `avatar` | `TEXT` | URL da foto (Google OAuth) |
+| `role` | `TEXT` | `'admin'` ou `'account'` |
+| `disabled` | `BOOLEAN` | Soft delete; `false` por padrão |
+| `created_at` | `TIMESTAMPTZ` | |
+
+> `password` é gerenciado exclusivamente pelo Supabase Auth — nunca armazenado em `profiles`.
+
+---
+
+## 2. Entidade: `projects`
+
+> Tela: **NewOnboarding** — dados coletados no wizard de criação de projeto
+
+### 2.1 Dados da Empresa
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `company_name` | text | `TEXT NOT NULL` | Nome da empresa cliente |
+| `cnpj` | text | `TEXT` | Opcional; sem validação de formato no front |
+| `business_type` | select | `TEXT NOT NULL` | Enum: `'b2b'`, `'local'`, `'ecommerce'`, `'infoproduto'` |
+| `segmento` | text / select | `TEXT` | Segmento de mercado; texto livre ou lista predefinida |
+| `responsible_name` | text | `TEXT NOT NULL` | Nome do responsável do cliente |
+| `responsible_role` | text | `TEXT` | Cargo do responsável |
+
+### 2.2 Contrato
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `contract_model` | select | `TEXT NOT NULL` | Enum: `'aceleracao'`, `'assessoria'` |
+| `contract_payment_type` | select | `TEXT` | Enum: `'unico'`, `'mensal'`; apenas para `aceleracao` |
+| `contract_value` | currency | `NUMERIC(12,2)` | Valor em BRL |
+| `contract_date` | date | `DATE NOT NULL` | Data de assinatura |
+| `competitors` | lista dinâmica | `TEXT[]` | Array de nomes de concorrentes |
+
+### 2.3 Equipe e Maturidade
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `has_sales_team` | radio (sim/não) | `BOOLEAN` | Nullable — tristate: sim, não, não informado |
+| `digital_maturity` | select (1–5) | `SMALLINT` | Escala 1 (Iniciante) a 5 (Expert) |
+| `upsell_potential` | radio (sim/não) | `BOOLEAN` | Nullable — tristate |
+| `upsell_notes` | textarea | `TEXT` | Notas livres sobre potencial de upsell |
+| `other_people` | lista dinâmica | `JSONB` | Array de `{name: TEXT, role: TEXT}` |
+
+### 2.4 Serviços Contratados
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `services` | checkbox array | `TEXT[]` | Lista de IDs de serviços selecionados |
+| `services_data` | sub-campos dinâmicos | `JSONB` | `{serviceId: {qty, nivel, imagemQty, videoQty, ...}}` |
+
+### 2.5 Documentos
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `raio_x_file_url` | file upload | `TEXT` | URL do arquivo no storage; PDF/imagem, máx 8 MB |
+| `sla_file_url` | file upload | `TEXT` | URL do arquivo no storage; PDF/imagem, máx 8 MB |
+
+### 2.6 Metadados do Projeto
+
+| Campo | Origem | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `account_id` | auth | `UUID NOT NULL REFERENCES profiles(id)` | Account manager responsável |
+| `status` | derivado | `TEXT NOT NULL DEFAULT 'onboarding'` | Enum: `'onboarding'`, `'active'` |
+| `completed_steps` | sistema | `TEXT[]` | Etapas concluídas: `['roi', 'strategy', 'oferta']` |
+| `created_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+| `updated_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+
+---
+
+## 3. Entidade: `roi_calculators`
+
+> Tela: **ProjectDetail → ROICalculator** (etapa obrigatória 1)
+> Um projeto pode ter múltiplos cenários — a FK `project_id` sem `UNIQUE` já permite isso.
+> Adicionar `name` é suficiente para diferenciar os cenários (ex: "Conservador", "Agressivo").
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `project_id` | FK | `UUID NOT NULL REFERENCES projects(id)` | Sem UNIQUE — permite múltiplos por projeto |
+| `name` | text | `TEXT NOT NULL DEFAULT 'Principal'` | Label do cenário |
+| `media_orcamento` | number | `NUMERIC(12,2)` | Orçamento em mídia; default 5000 |
+| `custo_marketing` | number | `NUMERIC(12,2)` | Management fee; default 2000 |
+| `ticket_medio` | number | `NUMERIC(12,2)` | Ticket médio; default 500 |
+| `qtd_compras` | number | `SMALLINT` | Compras por cliente (LTV); mín 1; default 1 |
+| `margem_bruta` | number (%) | `NUMERIC(5,2)` | 0–100%; default 40 |
+| `roi_desejado` | range slider | `NUMERIC(6,2)` | 0–500%; default 0 |
+| `taxa_lead_mql` | number (%) | `NUMERIC(5,2)` | Conversão Lead→MQL; default 30 |
+| `taxa_mql_sql` | number (%) | `NUMERIC(5,2)` | Conversão MQL→SQL; default 50 |
+| `taxa_sql_venda` | number (%) | `NUMERIC(5,2)` | Conversão SQL→Venda; default 20 |
+| `benchmark_type` | select | `TEXT` | Enum: `'b2b'`, `'b2c'` |
+| `created_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+
+---
+
+## 4. Entidade: `personas`
+
+> Tela: **ProjectDetail → PersonaCreator** (etapa obrigatória 2)
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `project_id` | FK | `UUID NOT NULL REFERENCES projects(id)` | |
+| `name` | text | `TEXT NOT NULL` | Nome da persona (label da aba) |
+| `answers` | multi-input dinâmico | `JSONB NOT NULL` | `{resultado: TEXT[], acoes: TEXT[], tempo: TEXT[], objecoes: TEXT[], sonhos: TEXT[], erros: TEXT[], medos: TEXT[], sinais: TEXT[], valores: TEXT[], habitos: TEXT[]}` — máx 10 respostas por questão |
+| `generated_content` | IA | `TEXT` | Markdown gerado pelo Claude após submissão do formulário |
+| `generated_at` | sistema | `TIMESTAMPTZ` | Momento da geração |
+| `created_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+
+---
+
+## 5. Entidade: `ofertas`
+
+> Tela: **ProjectDetail → OfertaMatadora** (etapa obrigatória 3)
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `project_id` | FK | `UUID NOT NULL REFERENCES projects(id)` | |
+| `answers` | multi-input | `JSONB NOT NULL` | `{nome: TEXT, resultado_sonho: TEXT, porque_vai_funcionar: TEXT, velocidade: TEXT, esforco_minimo: TEXT, bonus: TEXT[], garantia: TEXT, escassez: TEXT}` |
+| `generated_content` | IA | `TEXT` | Markdown gerado pelo Claude após submissão do formulário |
+| `generated_at` | sistema | `TIMESTAMPTZ` | Momento da geração |
+| `created_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+
+---
+
+## 6. Entidade: `campaign_plans`
+
+> Múltiplos planos por projeto — sem `UNIQUE` em `project_id`.
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `project_id` | FK | `UUID NOT NULL REFERENCES projects(id)` | Sem UNIQUE — permite múltiplos planos por projeto |
+| `name` | text | `TEXT NOT NULL DEFAULT 'Principal'` | Label do plano (ex: "Lançamento", "Manutenção") |
+| `answers` | estrutura aninhada | `JSONB NOT NULL` | `{orcamento_total: number, valor_ja_usado: number, channels: [{name, percentage, stages: [{name, percentage, campaigns: [{name, percentage}]}]}]}` — `budget_disponivel` é derivado (orcamento_total − valor_ja_usado) e não precisa ser salvo; valores de `name`: `'Meta Ads'`, `'Google Ads'`, `'LinkedIn Ads'`, `'TikTok Ads'`, `'YouTube Ads'` |
+| `created_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+
+---
+
+## 7. Entidade: `resultados` (tracking de métricas)
+
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `project_id` | FK | `UUID NOT NULL REFERENCES projects(id)` | `business_model` vem do projeto |
+| `period` | navegação | `DATE NOT NULL` | Data exata da semana registrada (ex: `2025-03-01`); semana derivada pelo dia: 1–7 = S1, 8–14 = S2, 15–21 = S3, 22+ = S4 |
+| `investido` | number | `NUMERIC(12,2)` | Verba investida em mídia no período (BRL) |
+| `leads` | number | `INTEGER` | Leads gerados no período |
+| `mql` | number | `INTEGER` | Marketing Qualified Leads |
+| `sql` | number | `INTEGER` | Sales Qualified Leads |
+| `vendas` | number | `INTEGER` | Vendas fechadas |
+| `valor_vendas` | number | `NUMERIC(12,2)` | Receita de vendas no período (BRL); relevante principalmente para B2C/e-commerce |
+
+> **Nota:** a separação B2B/B2C é derivada do campo `business_type` do projeto — não é armazenada em `resultados`.
+
+---
+
+## 8. Entidade: `criativos`
+
+> Múltiplos registros por projeto — sem `UNIQUE` em `project_id`.
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `project_id` | FK | `UUID NOT NULL REFERENCES projects(id)` | Sem UNIQUE — permite múltiplos ao longo do tempo |
+| `answers` | multi-input | `JSONB NOT NULL` | `{ad_type: TEXT, format: TEXT, quantity: SMALLINT}` — `ad_type`: 18 tipos (`'clickbait'`, `'sensacao'`, `'mito'`, `'dilema'`, `'prova'`, `'contraste'`, `'visual'`, etc.); `format`: `'static'` ou `'video'`; `quantity`: 1, 2, 3, 5 ou 10 |
+| `generated_content` | IA | `TEXT` | Markdown dos criativos gerados pelo Claude |
+| `rating` | RatingSelector | `TEXT` | Enum: `'bom'`, `'medio'`, `'ruim'`; nullable |
+| `generated_at` | sistema | `TIMESTAMPTZ` | Momento da geração |
+| `created_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+
+---
+
+## 9. Entidade: `google_ads`
+
+> Múltiplos registros por projeto — sem `UNIQUE` em `project_id`.
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `project_id` | FK | `UUID NOT NULL REFERENCES projects(id)` | Sem UNIQUE — permite múltiplos ao longo do tempo |
+| `answers` | multi-input | `JSONB NOT NULL` | `{campaign_types: TEXT[], keywords: TEXT, landing_page: TEXT, main_offer: TEXT, city: TEXT, objections: TEXT, custom_note: TEXT}` — `campaign_types`: um ou mais de `'marca'`, `'generico'`, `'concorrentes'`, `'problema'`; `keywords` obrigatório |
+| `generated_content` | IA | `TEXT` | Markdown gerado pelo Claude |
+| `rating` | RatingSelector | `TEXT` | Enum: `'bom'`, `'medio'`, `'ruim'`; nullable |
+| `generated_at` | sistema | `TIMESTAMPTZ` | Momento da geração |
+| `created_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+
+---
+
+## 10. Entidade: `landing_pages`
+
+> Múltiplos registros por projeto — sem `UNIQUE` em `project_id`.
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `project_id` | FK | `UUID NOT NULL REFERENCES projects(id)` | Sem UNIQUE — permite múltiplos ao longo do tempo |
+| `generated_content` | IA | `TEXT` | Markdown com todas as dobras gerado pelo Claude |
+| `rating` | RatingSelector | `TEXT` | Enum: `'bom'`, `'medio'`, `'ruim'`; nullable |
+| `generated_at` | sistema | `TIMESTAMPTZ` | Momento da geração |
+| `created_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+
+---
+
+## 11. Entidade: `banco_midia`
+
+> Biblioteca de marca do projeto — 1:1 com `projects`. Atualizada incrementalmente ao longo do tempo.
+> Não confundir com `documentos` (2.5 — dois arquivos fixos do onboarding) nem com `attachments` (13 — uploads avulsos).
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `project_id` | FK | `UUID PRIMARY KEY REFERENCES projects(id)` | PK e FK ao mesmo tempo — garante 1:1 sem coluna `id` extra |
+| `photos` | file upload (múltiplos) | `JSONB` | Array de `{url: TEXT, name: TEXT, size: INTEGER}`; .png/.jpg/.jpeg; máx 8 MB por arquivo; arquivos no Supabase Storage |
+| `videos` | file upload (múltiplos) | `JSONB` | Array de `{url: TEXT, name: TEXT, size: INTEGER}`; máx 50 MB por arquivo; arquivos no Supabase Storage |
+| `color_palette` | texto + cor | `JSONB` | Array de `{hex: TEXT, nome: TEXT}`; dado estruturado, não arquivo |
+| `logo_url` | file upload | `TEXT` | URL do logotipo no Storage (bucket `brand-logos`); NULL enquanto base64 legado |
+| `fonte_principal` | text | `TEXT` | Nome da fonte principal da marca |
+| `fonte_secundaria` | text | `TEXT` | Nome da fonte secundária da marca |
+| `fonte_obs` | textarea | `TEXT` | Observações sobre tipografia (variações, uso, restrições) |
+| `observacoes` | textarea | `TEXT` | Campo "O que evitar" — orientações livres sobre o que não usar nos criativos |
+| `updated_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | Atualizado a cada modificação na biblioteca |
+
+---
+
+## 12. Entidade: `estrategia`
+
+> Documento executivo gerado por IA a partir dos dados dos outros módulos — sem inputs próprios do usuário.
+> 1:1 com o projeto; pode ser regenerada a qualquer momento.
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `project_id` | FK | `UUID PRIMARY KEY REFERENCES projects(id)` | PK e FK ao mesmo tempo — garante 1:1 |
+| `narrativa` | IA | `TEXT` | Markdown com a estratégia digital completa (7 seções) gerado pelo Claude |
+| `generated_at` | sistema | `TIMESTAMPTZ` | Atualizado a cada regeneração |
+
+---
+
+## 13. Entidade: `estrategia_v2`
+
+> Análise estratégica estruturada com inputs do usuário — complementar à narrativa gerada por IA da `estrategia`.
+> 1:1 com o projeto; seções de ICPs, ROI e campanhas são read-only (lidas de outras entidades, não salvas aqui).
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `project_id` | FK | `UUID PRIMARY KEY REFERENCES projects(id)` | PK e FK ao mesmo tempo — garante 1:1 |
+| `problemas` | lista dinâmica | `TEXT[]` | Problemas identificados no kickoff; máx 10 itens |
+| `swot` | textarea por quadrante | `JSONB NOT NULL` | `{forcas: TEXT, fraquezas: TEXT, oportunidades: TEXT, ameacas: TEXT}` |
+| `concorrentes` | formulário dinâmico | `JSONB` | Array de `{nome: TEXT, metaAds: BOOLEAN, googleAds: BOOLEAN, linkBiblioteca: TEXT, grandePromessa: TEXT, comunicacao: TEXT}` — `linkBiblioteca` só preenchido quando `metaAds = true` |
+| `riscos` | tabela dinâmica | `JSONB` | Array de `{problema: TEXT, riscoGerado: TEXT, impacto: TEXT, nivel: TEXT}` — `nivel`: `'baixo'`, `'medio'`, `'alto'` |
+| `funis` | checkbox múltiplo | `TEXT[]` | Funis selecionados; opções: `'Funil de Webinar'`, `'Funil de Aplicação'`, `'Funil de Diagnóstico'`, `'Funil de E-commerce (Venda Direta)'`, `'Funil de Webinar Pago'`, `'Funil de Isca Digital'`, `'Funil de VSL'`, `'Funil de Quiz'`, `'Lançamento'`, `'Funil de Desafio'`, `'Funil Win-Your-Money-Back'` |
+| `updated_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | Atualizado a cada salvamento |
+
+---
+
+## 14. Entidade: `attachments`
+
+> ⚠️ Atualmente os arquivos são armazenados como **base64 no JSONB** de `projects.data` — isso não escala. Na migração, o conteúdo físico deve ir para o **Supabase Storage** e apenas os metadados ficam nesta tabela.
+
+| Campo | Input | Tipo SQL sugerido | Observações |
+|---|---|---|---|
+| `id` | gerado | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | |
+| `project_id` | FK | `UUID NOT NULL REFERENCES projects(id)` | |
+| `name` | upload | `TEXT NOT NULL` | Nome original do arquivo |
+| `size` | upload | `INTEGER NOT NULL` | Tamanho em bytes; máx 8 MB por arquivo, 30 MB total por projeto |
+| `type` | upload | `TEXT NOT NULL` | MIME type (ex: `'application/pdf'`, `'image/png'`) |
+| `storage_path` | sistema | `TEXT NOT NULL` | Caminho no Supabase Storage bucket (substitui o `data` base64 atual) |
+| `uploaded_at` | sistema | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
+
+---
+
+## Resumo de Tipos por Categoria
+
+| Categoria de Input | Tipo SQL Recomendado |
+|---|---|
+| Textos livres curtos | `TEXT` |
+| Textos longos / markdown | `TEXT` |
+| Emails | `TEXT NOT NULL UNIQUE` |
+| Valores monetários (BRL) | `NUMERIC(12,2)` |
+| Percentuais | `NUMERIC(5,2)` |
+| Contagens / quantidades | `INTEGER` ou `SMALLINT` |
+| Escalas (1–5) | `SMALLINT` |
+| Datas | `DATE` |
+| Timestamps | `TIMESTAMPTZ NOT NULL DEFAULT now()` |
+| Booleanos (sim/não) | `BOOLEAN` (nullable para tristate) |
+| Enums simples | `TEXT` com check constraint |
+| Arrays simples | `TEXT[]` |
+| Estruturas aninhadas / dinâmicas | `JSONB` |
+| IDs externos / URLs | `TEXT` |
+| PKs | `UUID DEFAULT gen_random_uuid()` |
+| FKs | `UUID NOT NULL REFERENCES tabela(id)` |
+| Outputs de IA | `TEXT` (markdown) |

--- a/scripts/migrate-attachments-to-storage.js
+++ b/scripts/migrate-attachments-to-storage.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * migrate-attachments-to-storage.js
+ * Faz upload dos arquivos base64 da tabela legada `projects` para o Supabase Storage
+ * e atualiza storage_path em `attachments` e logo_url em `banco_midia`.
+ *
+ * Uso:
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/migrate-attachments-to-storage.js
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "fs";
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SERVICE_KEY  = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error("❌ Defina SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// Ler mapeamento legacyId → newUUID (pega o mais recente)
+const mapFiles = (await import("fs")).readdirSync("./scripts").filter(f => f.startsWith("id-map-")).sort();
+if (!mapFiles.length) { console.error("❌ Nenhum id-map-*.json encontrado em scripts/"); process.exit(1); }
+const idMap = JSON.parse(readFileSync(`./scripts/${mapFiles.at(-1)}`, "utf8"));
+console.log(`📋 Usando mapeamento: ${mapFiles.at(-1)}\n`);
+
+// ─── Helper: base64 data URI → Buffer + contentType ───────────────────────────
+function parseDataUri(dataUri) {
+  const match = dataUri.match(/^data:([^;]+);base64,(.+)$/s);
+  if (!match) return null;
+  return {
+    contentType: match[1],
+    buffer: Buffer.from(match[2], "base64"),
+  };
+}
+
+// ─── Helper: sanitiza nome de arquivo para Storage ────────────────────────────
+function safeName(name) {
+  return name.replace(/[^a-zA-Z0-9._\-]/g, "_").replace(/_+/g, "_");
+}
+
+// ─── Upload para Storage ──────────────────────────────────────────────────────
+async function upload(bucket, path, buffer, contentType) {
+  const { error } = await supabase.storage.from(bucket).upload(path, buffer, {
+    contentType,
+    upsert: true,
+  });
+  if (error) throw new Error(`Storage upload (${bucket}/${path}): ${error.message}`);
+  return path;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+const { data: legacyRows } = await supabase.from("projects").select("id, data");
+
+let totalUploaded = 0, totalErrors = 0;
+
+for (const row of legacyRows) {
+  const d        = row.data ?? {};
+  const newId    = idMap[String(row.id)];
+  const name     = d.companyName ?? d.company_name ?? row.id;
+
+  if (!newId) { console.warn(`⚠️  Sem mapeamento para ${row.id} — pulando`); continue; }
+
+  // ── Anexos (PDFs / docs) ─────────────────────────────────────────────────
+  const attachments = (d.attachments ?? []).filter(a => a.data?.startsWith("data:"));
+  if (attachments.length) {
+    console.log(`\n📁 ${name} — ${attachments.length} anexo(s)`);
+    for (const a of attachments) {
+      const parsed = parseDataUri(a.data);
+      if (!parsed) { console.warn(`  ⚠️  Formato inválido: ${a.name}`); continue; }
+
+      const storagePath = `${newId}/${safeName(a.name)}`;
+      try {
+        await upload("attachments", storagePath, parsed.buffer, parsed.contentType);
+        // Atualizar storage_path na tabela attachments
+        const { error } = await supabase
+          .from("attachments")
+          .update({ storage_path: storagePath })
+          .eq("project_id", newId)
+          .eq("name", a.name);
+        if (error) throw new Error(error.message);
+        console.log(`  ✓ ${a.name} (${Math.round(parsed.buffer.length / 1024)} KB)`);
+        totalUploaded++;
+      } catch (err) {
+        console.error(`  ❌ ${a.name}: ${err.message}`);
+        totalErrors++;
+      }
+    }
+  }
+
+  // ── Logo ─────────────────────────────────────────────────────────────────
+  const logo = d.brandKit?.logo;
+  if (logo?.startsWith("data:")) {
+    const parsed = parseDataUri(logo);
+    if (parsed) {
+      const ext = parsed.contentType.split("/")[1] ?? "png";
+      const storagePath = `${newId}/logo.${ext}`;
+      try {
+        await upload("brand-logos", storagePath, parsed.buffer, parsed.contentType);
+        const { error } = await supabase
+          .from("banco_midia")
+          .upsert({ project_id: newId, logo_url: storagePath }, { onConflict: "project_id" });
+        if (error) throw new Error(error.message);
+        console.log(`\n🏷  ${name} — logo migrada (${Math.round(parsed.buffer.length / 1024)} KB)`);
+        totalUploaded++;
+      } catch (err) {
+        console.error(`\n❌ ${name} logo: ${err.message}`);
+        totalErrors++;
+      }
+    }
+  }
+}
+
+console.log(`\n─────────────────────────────────`);
+console.log(`✅ Uploads: ${totalUploaded} | ❌ Erros: ${totalErrors}`);
+if (totalErrors === 0) console.log(`\n🎉 Todos os arquivos migrados com sucesso!`);
+else console.log(`\n⚠️  Verifique os erros acima e rode novamente se necessário.`);

--- a/scripts/migrate-from-legacy.js
+++ b/scripts/migrate-from-legacy.js
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+/**
+ * migrate-from-legacy.js
+ * Migra dados da tabela `projects` (JSONB) para o schema normalizado (projects_v2 + tabelas filhas).
+ *
+ * Uso:
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/migrate-from-legacy.js
+ *
+ * Flags opcionais:
+ *   --dry-run   Apenas lê e mostra o que seria migrado, sem escrever no banco
+ *   --project-id=<id>  Migra apenas um projeto específico (legacy_id)
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { randomUUID } from "crypto";
+import { writeFileSync } from "fs";
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SERVICE_KEY  = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error("❌ Defina SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const DRY_RUN     = process.argv.includes("--dry-run");
+const TARGET_ID   = process.argv.find((a) => a.startsWith("--project-id="))?.split("=")[1];
+const idMap       = {};   // legacyId → newUUID
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+function log(...args) { console.log(...args); }
+function warn(...args) { console.warn("⚠️ ", ...args); }
+
+async function insert(table, rows) {
+  if (DRY_RUN) { log(`  [dry] INSERT ${table} (${rows.length} rows)`); return; }
+  const { error } = await supabase.from(table).insert(rows);
+  if (error) warn(`INSERT ${table}: ${error.message}`);
+}
+
+async function upsert(table, rows, opts = {}) {
+  if (DRY_RUN) { log(`  [dry] UPSERT ${table} (${rows.length} rows)`); return; }
+  const { error } = await supabase.from(table).upsert(rows, opts);
+  if (error) warn(`UPSERT ${table}: ${error.message}`);
+}
+
+// ─── Converte data legada → row de projects_v2 ────────────────────────────────
+function buildProjectRow(legacyId, d, accountId) {
+  return {
+    id:                    randomUUID(),
+    legacy_id:             String(legacyId),
+    company_name:          d.companyName          ?? d.company_name          ?? "",
+    cnpj:                  d.cnpj                 ?? null,
+    business_type:         d.businessType         ?? d.business_type         ?? "b2b",
+    segmento:              d.segmento             ?? null,
+    responsible_name:      d.responsibleName      ?? d.responsible_name      ?? "",
+    responsible_role:      d.responsibleRole      ?? d.responsible_role      ?? null,
+    contract_model:        d.contractModel        ?? d.contract_model        ?? "aceleracao",
+    contract_payment_type: d.contractPaymentType  ?? d.contract_payment_type ?? null,
+    contract_value:        d.contractValue        ?? d.contract_value        ?? null,
+    contract_date:         d.contractDate         ?? d.contract_date         ?? null,
+    competitors:           d.competitors          ?? [],
+    has_sales_team:        d.hasSalesTeam         ?? d.has_sales_team        ?? null,
+    digital_maturity:      d.digitalMaturity      ?? d.digital_maturity      ?? null,
+    upsell_potential:      d.upsellPotential      ?? d.upsell_potential      ?? null,
+    upsell_notes:          d.upsellNotes          ?? d.upsell_notes          ?? null,
+    other_people:          d.otherPeople          ?? d.other_people          ?? [],
+    services:              d.services             ?? [],
+    services_data:         d.servicesData         ?? d.services_data         ?? null,
+    raio_x_file_url:       d.raioXFileName        ?? d.raio_x_file_url       ?? null,
+    sla_file_url:          d.slaFileName          ?? d.sla_file_url          ?? null,
+    account_id:            d.accountId            ?? accountId,
+    status:                d.status               ?? "onboarding",
+    completed_steps:       d.completedSteps       ?? d.completed_steps       ?? [],
+    created_at:            d.createdAt            ?? d.created_at            ?? new Date().toISOString(),
+    updated_at:            d.updatedAt            ?? d.updated_at            ?? new Date().toISOString(),
+  };
+}
+
+// ─── Migra roi_calculators ────────────────────────────────────────────────────
+async function migrateROI(projectId, d) {
+  const roi = d.roiCalc ?? d.roi_calc;
+  if (!roi) return;
+  await upsert("roi_calculators", [{
+    id:              randomUUID(),
+    project_id:      projectId,
+    name:            roi.name            ?? "Principal",
+    media_orcamento: roi.mediaOrcamento  ?? roi.media_orcamento  ?? null,
+    custo_marketing: roi.custoMarketing  ?? roi.custo_marketing  ?? null,
+    ticket_medio:    roi.ticketMedio     ?? roi.ticket_medio     ?? null,
+    qtd_compras:     roi.qtdCompras      ?? roi.qtd_compras      ?? null,
+    margem_bruta:    roi.margemBruta     ?? roi.margem_bruta     ?? null,
+    roi_desejado:    roi.roiDesejado     ?? roi.roi_desejado     ?? null,
+    taxa_lead_mql:   roi.taxaLead2MQL    ?? roi.taxaLeadMql     ?? roi.taxa_lead_mql    ?? null,
+    taxa_mql_sql:    roi.taxaMQL2SQL     ?? roi.taxaMqlSql      ?? roi.taxa_mql_sql     ?? null,
+    taxa_sql_venda:  roi.taxaSQL2Venda   ?? roi.taxaSqlVenda    ?? roi.taxa_sql_venda   ?? null,
+    benchmark_type:  roi.benchmarkType   ?? roi.benchmark_type   ?? null,
+    result:          d.roiResult         ?? null,
+  }], { onConflict: "id" });
+}
+
+// ─── Migra personas ───────────────────────────────────────────────────────────
+async function migratePersonas(projectId, d) {
+  const personas = d.personas;
+  if (!Array.isArray(personas) || personas.length === 0) return;
+  await insert("personas", personas.map((p) => ({
+    id:               randomUUID(),
+    project_id:       projectId,
+    name:             p.name             ?? "Persona",
+    answers:          p.answers          ?? {},
+    generated_content:p.generatedProfile  ?? p.generatedContent ?? p.generated_content ?? null,
+    generated_at:     p.generatedAt      ?? p.generated_at      ?? null,
+  })));
+}
+
+// ─── Migra ofertas ────────────────────────────────────────────────────────────
+async function migrateOferta(projectId, d) {
+  const oferta = d.ofertaData ?? d.oferta_data;
+  if (!oferta) return;
+  await upsert("ofertas", [{
+    id:               randomUUID(),
+    project_id:       projectId,
+    answers:          oferta.answers ?? oferta,
+    generated_content:oferta.generatedOffer ?? oferta.generatedContent ?? oferta.generated_content ?? null,
+    generated_at:     oferta.generatedAt    ?? oferta.generated_at     ?? null,
+  }], { onConflict: "project_id" });
+}
+
+// ─── Migra campaign_plans ─────────────────────────────────────────────────────
+async function migrateCampaignPlan(projectId, d) {
+  const plan = d.campaignPlan ?? d.campaign_plan;
+  if (!plan) return;
+  await upsert("campaign_plans", [{
+    id:         randomUUID(),
+    project_id: projectId,
+    name:       plan.name    ?? "Principal",
+    answers:    plan.answers ?? plan,
+  }], { onConflict: "id" });
+}
+
+// ─── Migra criativos ──────────────────────────────────────────────────────────
+async function migrateCriativos(projectId, d) {
+  const creatives = d.creatives ?? [];
+  if (!Array.isArray(creatives) || creatives.length === 0) return;
+  await insert("criativos", creatives.map((c) => ({
+    id:               randomUUID(),
+    project_id:       projectId,
+    answers:          { adTypeLabels: c.adTypeLabels, quantity: c.quantity, customNote: c.customNote, isVideo: c.isVideo },
+    generated_content:c.content    ?? null,
+    rating:           c.rating     ?? null,
+    generated_at:     c.createdAt  ?? null,
+  })));
+}
+
+// ─── Migra google_ads ─────────────────────────────────────────────────────────
+async function migrateGoogleAds(projectId, d) {
+  const ads = d.googleAds ?? d.google_ads ?? [];
+  if (!Array.isArray(ads) || ads.length === 0) return;
+  await insert("google_ads", ads.map((g) => ({
+    id:               randomUUID(),
+    project_id:       projectId,
+    answers:          { campaignTypes: g.campaignTypes, keywords: g.keywords, city: g.city },
+    generated_content:g.content   ?? null,
+    rating:           g.rating    ?? null,
+    generated_at:     g.createdAt ?? null,
+  })));
+}
+
+// ─── Migra landing_pages ──────────────────────────────────────────────────────
+async function migrateLandingPages(projectId, d) {
+  const lps = d.landingPages ?? d.landing_pages ?? [];
+  if (!Array.isArray(lps) || lps.length === 0) return;
+  await insert("landing_pages", lps.map((lp) => ({
+    id:               randomUUID(),
+    project_id:       projectId,
+    generated_content:lp.content ?? lp.generatedContent ?? null,
+    rating:           lp.rating  ?? null,
+    generated_at:     lp.createdAt ?? lp.generated_at ?? null,
+  })));
+}
+
+// ─── Migra estrategia ─────────────────────────────────────────────────────────
+async function migrateEstrategia(projectId, d) {
+  const e = d.estrategia;
+  if (!e) return;
+  const narrativa = typeof e === "string" ? e : e.narrativa ?? null;
+  if (!narrativa) return;
+  await upsert("estrategia", [{
+    project_id:   projectId,
+    narrativa,
+    generated_at: e.updatedAt ?? e.generated_at ?? null,
+  }], { onConflict: "project_id" });
+}
+
+// ─── Migra estrategia_v2 ──────────────────────────────────────────────────────
+async function migrateEstrategiaV2(projectId, d) {
+  const ev2 = d.estrategiaV2 ?? d.estrategia_v2;
+  if (!ev2) return;
+  await upsert("estrategia_v2", [{
+    project_id:   projectId,
+    problemas:    ev2.problemas    ?? [],
+    swot:         ev2.swot         ?? {},
+    concorrentes: ev2.concorrentes ?? [],
+    riscos:       ev2.riscos       ?? [],
+    funis:        ev2.funis        ?? [],
+  }], { onConflict: "project_id" });
+}
+
+// ─── Migra banco_midia (sem upload de binários) ───────────────────────────────
+async function migrateBancoMidia(projectId, d) {
+  const kit  = d.brandKit   ?? {};
+  const fotos  = d.brandFotos  ?? [];
+  const videos = d.brandVideos ?? [];
+
+  // Filtra base64 (fotos/vídeos que têm campo `data` são base64 — precisam de Storage)
+  const photosClean = fotos.map(({ data: _omit, ...rest }) => rest);
+  const videosClean = videos.map(({ data: _omit, ...rest }) => rest);
+
+  const hasData = photosClean.length > 0 || videosClean.length > 0 ||
+    kit.colorPalette?.length > 0 || kit.fontePrincipal || d.observacoesMidia;
+  if (!hasData) return;
+
+  await upsert("banco_midia", [{
+    project_id:      projectId,
+    photos:          photosClean.length ? photosClean : null,
+    videos:          videosClean.length ? videosClean : null,
+    color_palette:   kit.colorPalette    ?? null,
+    logo_url:        null,   // base64 logo não migrado; fazer upload manual
+    fonte_principal: kit.fontePrincipal  ?? null,
+    fonte_secundaria:kit.fonteSecundaria ?? null,
+    fonte_obs:       kit.fonteObs        ?? null,
+    observacoes:     d.observacoesMidia  ?? null,
+  }], { onConflict: "project_id" });
+
+  if (fotos.some((f) => f.data) || videos.some((v) => v.data) || kit.logo) {
+    warn(`Projeto ${projectId}: arquivos base64 (fotos/vídeos/logo) não migrados → fazer upload manual para Storage`);
+  }
+}
+
+// ─── Migra attachments (sem upload de binários) ───────────────────────────────
+async function migrateAttachments(projectId, d) {
+  const attachments = d.attachments ?? [];
+  if (!Array.isArray(attachments) || attachments.length === 0) return;
+  const rows = attachments.map((a) => ({
+    id:           randomUUID(),
+    project_id:   projectId,
+    name:         a.name,
+    size:         a.size,
+    type:         a.type ?? "application/octet-stream",
+    storage_path: null,   // base64 não migrado; null até upload manual
+    uploaded_at:  a.uploadedAt ?? a.uploaded_at ?? new Date().toISOString(),
+  }));
+  await insert("attachments", rows);
+  if (attachments.some((a) => a.data)) {
+    warn(`Projeto ${projectId}: ${attachments.filter((a) => a.data).length} anexo(s) base64 não migrados → fazer upload manual`);
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  log(`\n🚀 Iniciando migração${DRY_RUN ? " (DRY RUN)" : ""}...\n`);
+
+  // Buscar projetos legados
+  let query = supabase.from("projects").select("id, data");
+  if (TARGET_ID) query = query.eq("id", TARGET_ID);
+  const { data: legacyRows, error } = await query;
+  if (error) { console.error("❌ Erro ao ler tabela projects:", error.message); process.exit(1); }
+
+  log(`📦 ${legacyRows.length} projeto(s) encontrado(s) na tabela legada\n`);
+
+  for (const row of legacyRows) {
+    const legacyId = row.id;
+    const d        = row.data ?? {};
+    log(`─── Projeto legado: ${legacyId} (${d.companyName ?? d.company_name ?? "sem nome"})`);
+
+    const projectRow = buildProjectRow(legacyId, d, d.accountId ?? d.account_id);
+    const newId      = projectRow.id;
+    idMap[legacyId]  = newId;
+
+    // 1. projects_v2
+    if (DRY_RUN) {
+      log(`  [dry] INSERT projects_v2 → ${newId}`);
+    } else {
+      const { error: pErr } = await supabase.from("projects_v2").insert(projectRow);
+      if (pErr) { warn(`INSERT projects_v2: ${pErr.message}`); continue; }
+      log(`  ✓ projects_v2 → ${newId}`);
+    }
+
+    // 2. Tabelas filhas
+    await migrateROI(newId, d);
+    await migratePersonas(newId, d);
+    await migrateOferta(newId, d);
+    await migrateCampaignPlan(newId, d);
+    await migrateCriativos(newId, d);
+    await migrateGoogleAds(newId, d);
+    await migrateLandingPages(newId, d);
+    await migrateEstrategia(newId, d);
+    await migrateEstrategiaV2(newId, d);
+    await migrateBancoMidia(newId, d);
+    await migrateAttachments(newId, d);
+
+    log(`  ✓ Relações migradas\n`);
+  }
+
+  // Salvar mapeamento
+  const mapPath = `./scripts/id-map-${Date.now()}.json`;
+  writeFileSync(mapPath, JSON.stringify(idMap, null, 2));
+  log(`\n✅ Migração concluída. Mapeamento salvo em: ${mapPath}`);
+  log(`\n📌 Próximos passos:`);
+  log(`   1. Verificar integridade: SELECT count(*) FROM projects_v2;`);
+  log(`   2. Fazer upload manual dos arquivos base64 para Supabase Storage`);
+  log(`   3. Limpar localStorage no browser: localStorage.clear()`);
+  log(`   4. Em produção: após validar, dropar projects e renomear projects_v2 → projects`);
+}
+
+main().catch((err) => { console.error("❌ Erro fatal:", err); process.exit(1); });

--- a/src/components/AnexosModule.jsx
+++ b/src/components/AnexosModule.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react'
 import { useApp } from '../context/AppContext'
+import { getSignedUrl } from '../lib/supabase'
 import {
   Upload, Paperclip, Download, Trash2, AlertCircle,
   FileText, Image, File, FileSpreadsheet, FileVideo,
@@ -105,9 +106,24 @@ export default function AnexosModule({ project }) {
     updateProject(project.id, { attachments: attachments.filter((a) => a.id !== id) })
   }, [attachments, project.id, updateProject])
 
-  const handleDownload = useCallback((a) => {
+  const handleDownload = useCallback(async (a) => {
+    let href = a.data  // base64 para uploads novos (ainda não migrados)
+
+    if (!href && a.storage_path) {
+      href = await getSignedUrl('attachments', a.storage_path)
+      if (!href) {
+        setError('Erro ao gerar link de download. Tente novamente.')
+        return
+      }
+    }
+
+    if (!href) {
+      setError('Arquivo não disponível para download.')
+      return
+    }
+
     const link = document.createElement('a')
-    link.href     = a.data
+    link.href     = href
     link.download = a.name
     document.body.appendChild(link)
     link.click()

--- a/src/components/BancoMidiaModule.jsx
+++ b/src/components/BancoMidiaModule.jsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { useApp } from '../context/AppContext'
+import { getSignedUrl } from '../lib/supabase'
 import {
   Upload, Download, Trash2, AlertCircle, Plus, X,
   Image, Film, Palette, Type, AlertTriangle, Camera,
@@ -177,14 +178,25 @@ export default function BancoMidiaModule({ project }) {
   const photoInputRef = useRef(null)
   const videoInputRef = useRef(null)
 
-  const [error,    setError]    = useState(null)
-  const [newColor, setNewColor] = useState({ hex: '#164496', nome: '' })
+  const [error,      setError]      = useState(null)
+  const [newColor,   setNewColor]   = useState({ hex: '#164496', nome: '' })
   const [showAddColor, setShowAddColor] = useState(false)
+  const [logoSrc,    setLogoSrc]    = useState(null)
 
   // ── Data shortcuts ──────────────────────────────────────────────────────────
   const kit    = project.brandKit    || {}
   const fotos  = project.brandFotos  || []
   const videos = project.brandVideos || []
+
+  // ── Resolve logo: base64 direto ou signed URL do Storage ───────────────────
+  useEffect(() => {
+    if (!kit.logo) { setLogoSrc(null); return }
+    if (kit.logo.startsWith('data:') || kit.logo.startsWith('http')) {
+      setLogoSrc(kit.logo)
+    } else {
+      getSignedUrl('brand-logos', kit.logo).then((url) => setLogoSrc(url))
+    }
+  }, [kit.logo])
 
   function saveKit(patch) {
     updateProject(project.id, { brandKit: { ...kit, ...patch } })
@@ -295,9 +307,9 @@ export default function BancoMidiaModule({ project }) {
               onClick={() => logoInputRef.current?.click()}
               className="relative group cursor-pointer w-full aspect-video rounded-xl border-2 border-dashed border-rl-border hover:border-rl-purple/50 bg-rl-surface flex items-center justify-center overflow-hidden transition-all"
             >
-              {kit.logo ? (
+              {logoSrc ? (
                 <>
-                  <img src={kit.logo} alt="Logo" className="w-full h-full object-contain p-3" />
+                  <img src={logoSrc} alt="Logo" className="w-full h-full object-contain p-3" />
                   <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                     <Camera className="w-5 h-5 text-white" />
                   </div>
@@ -309,7 +321,7 @@ export default function BancoMidiaModule({ project }) {
                 </div>
               )}
             </div>
-            {kit.logo && (
+            {logoSrc && (
               <button
                 onClick={() => saveKit({ logo: null })}
                 className="w-full text-xs text-rl-red/70 hover:text-rl-red transition-colors"

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -10,7 +10,7 @@ import { supabase, isSupabaseReady } from "../lib/supabase";
 
 const AppContext = createContext();
 
-// Enrich a Supabase auth user with user_metadata
+// ─── Helpers de usuário ────────────────────────────────────────────────────────
 function enrichUser(authUser) {
   if (!authUser) return null;
   const meta = authUser.user_metadata || {};
@@ -23,34 +23,470 @@ function enrichUser(authUser) {
   };
 }
 
-// ─── Supabase helpers ──────────────────────────────────────────────────────────
+// ─── Monta objeto de projeto em memória a partir da row + relações ─────────────
+// Expõe TANTO snake_case (DB) quanto camelCase (compat com componentes existentes)
+function assembleProject(row, rel = {}) {
+  const {
+    rois        = [],
+    personas    = [],
+    ofertas     = [],
+    campaigns   = [],
+    criativos   = [],
+    googleAds   = [],
+    landingPages = [],
+    bancoMidia  = null,
+    estrategia  = null,
+    estrategiaV2 = null,
+    attachments = [],
+    resultados  = [],
+  } = rel;
+
+  const progress = Math.min(
+    100,
+    Math.round(
+      ((row.completed_steps || []).filter((s) => ["roi", "strategy", "oferta"].includes(s)).length / 3) * 100,
+    ),
+  );
+
+  return {
+    // ── Campos DB snake_case ────────────────────────────────────────────────
+    ...row,
+    completed_steps: row.completed_steps || [],
+    services:        row.services        || [],
+    competitors:     row.competitors     || [],
+    other_people:    row.other_people    || [],
+
+    // ── Aliases camelCase para compat com componentes existentes ───────────
+    companyName:          row.company_name,
+    businessType:         row.business_type,
+    segmento:             row.segmento,
+    responsibleName:      row.responsible_name,
+    responsibleRole:      row.responsible_role,
+    contractModel:        row.contract_model,
+    contractPaymentType:  row.contract_payment_type,
+    contractValue:        row.contract_value,
+    contractDate:         row.contract_date,
+    hasSalesTeam:         row.has_sales_team,
+    digitalMaturity:      row.digital_maturity,
+    upsellPotential:      row.upsell_potential,
+    upsellNotes:          row.upsell_notes,
+    otherPeople:          row.other_people || [],
+    servicesData:         row.services_data,
+    raioXFileName:        row.raio_x_file_url,
+    slaFileName:          row.sla_file_url,
+    accountId:            row.account_id,
+    completedSteps:       row.completed_steps || [],
+    createdAt:            row.created_at,
+    progress,
+
+    // ── Relações ────────────────────────────────────────────────────────────
+    // Personas: mapear generated_content (DB) → generatedProfile (componente)
+    personas: personas.map((p) => ({
+      ...p,
+      generatedProfile: p.generated_content ?? null,
+    })),
+
+    roiCalc: rois[0] ? {
+      ...rois[0],
+      // aliases camelCase com números — formato esperado pelo ROICalculator
+      mediaOrcamento: rois[0].media_orcamento,
+      custoMarketing: rois[0].custo_marketing,
+      ticketMedio:    rois[0].ticket_medio,
+      qtdCompras:     rois[0].qtd_compras,
+      margemBruta:    rois[0].margem_bruta,
+      roiDesejado:    rois[0].roi_desejado,
+      taxaLead2MQL:   rois[0].taxa_lead_mql,
+      taxaMQL2SQL:    rois[0].taxa_mql_sql,
+      taxaSQL2Venda:  rois[0].taxa_sql_venda,
+      benchmarkType:  rois[0].benchmark_type,
+    } : null,
+    roiResult:    rois[0]?.result ?? null,
+    ofertaData: ofertas[0] ? {
+      id:           ofertas[0].id,
+      // Suporta tanto a row bruta do DB (com answers + generated_content)
+      // quanto o objeto já montado (flat, passado pelo handler de realtime)
+      ...(typeof ofertas[0].answers === 'object' && ofertas[0].answers !== null
+        ? ofertas[0].answers
+        : ofertas[0]),
+      generatedOffer: ofertas[0].generated_content ?? ofertas[0].generatedOffer ?? null,
+    } : null,
+    campaignPlan: campaigns[0] ? {
+      id:   campaigns[0].id,
+      name: campaigns[0].name,
+      ...(typeof campaigns[0].answers === 'object' && campaigns[0].answers !== null
+        ? campaigns[0].answers
+        : campaigns[0]),
+    } : null,
+    creatives: criativos.map((c) => ({
+      id:      c.id,
+      rating:  c.rating  ?? null,
+      ...(typeof c.answers === 'object' && c.answers !== null ? c.answers : c),
+      content: c.generated_content ?? c.content ?? null,
+    })),
+    googleAds: googleAds.map((g) => ({
+      id:      g.id,
+      rating:  g.rating  ?? null,
+      ...(typeof g.answers === 'object' && g.answers !== null ? g.answers : g),
+      content: g.generated_content ?? g.content ?? null,
+    })),
+    landingPages: landingPages.map((lp) => ({
+      id:      lp.id,
+      rating:  lp.rating ?? null,
+      content: lp.generated_content ?? lp.content ?? null,
+    })),
+    // resultados: usa o campo JSONB `data` que preserva o objeto aninhado do componente
+    resultados: resultados[0]?.data ?? {},
+    attachments,
+
+    // banco_midia: expõe tanto o objeto completo quanto aliases diretos
+    bancoMidia,
+    brandFotos:   bancoMidia?.photos       ?? [],
+    brandVideos:  bancoMidia?.videos       ?? [],
+    brandKit: bancoMidia ? {
+      cores:          bancoMidia.color_palette  ?? [],
+      logo:           bancoMidia.logo_url        ?? null, // path no Storage; BancoMidiaModule gera signed URL
+      fontePrincipal: bancoMidia.fonte_principal ?? "",
+      fonteSecundaria:bancoMidia.fonte_secundaria ?? "",
+      fonteObs:       bancoMidia.fonte_obs        ?? "",
+    } : null,
+    observacoesMidia: bancoMidia?.observacoes ?? "",
+
+    // estrategia
+    estrategia:   estrategia
+      ? { narrativa: estrategia.narrativa, updatedAt: estrategia.generated_at }
+      : null,
+    estrategiaV2: estrategiaV2 ?? null,
+  };
+}
+
+// ─── Supabase: busca todos os projetos + relações ──────────────────────────────
 async function sbFetchAll() {
   if (!supabase) return null;
-  const { data, error } = await supabase
-    .from("projects")
-    .select("id, data")
+
+  const { data: projects, error: pErr } = await supabase
+    .from("projects_v2")
+    .select("*")
     .order("created_at", { ascending: false });
-  if (error) {
-    console.error("[Supabase] fetch:", error.message);
-    return null;
+
+  if (pErr) { console.error("[Supabase] fetch projects_v2:", pErr.message); return null; }
+  if (!projects.length) return [];
+
+  const ids = projects.map((p) => p.id);
+
+  const [
+    { data: rois },
+    { data: personasData },
+    { data: ofertasData },
+    { data: campaignsData },
+    { data: criativosData },
+    { data: googleAdsData },
+    { data: lpData },
+    { data: bancoData },
+    { data: estrategiaData },
+    { data: ev2Data },
+    { data: attachmentsData },
+    { data: resultadosData },
+  ] = await Promise.all([
+    supabase.from("roi_calculators").select("*").in("project_id", ids),
+    supabase.from("personas").select("*").in("project_id", ids),
+    supabase.from("ofertas").select("*").in("project_id", ids),
+    supabase.from("campaign_plans").select("*").in("project_id", ids),
+    supabase.from("criativos").select("*").in("project_id", ids),
+    supabase.from("google_ads").select("*").in("project_id", ids),
+    supabase.from("landing_pages").select("*").in("project_id", ids),
+    supabase.from("banco_midia").select("*").in("project_id", ids),
+    supabase.from("estrategia").select("*").in("project_id", ids),
+    supabase.from("estrategia_v2").select("*").in("project_id", ids),
+    supabase.from("attachments").select("*").in("project_id", ids),
+    supabase.from("resultados").select("*").in("project_id", ids),
+  ]);
+
+  return projects.map((p) =>
+    assembleProject(p, {
+      rois:         (rois         || []).filter((r) => r.project_id === p.id),
+      personas:     (personasData || []).filter((r) => r.project_id === p.id),
+      ofertas:      (ofertasData  || []).filter((r) => r.project_id === p.id),
+      campaigns:    (campaignsData|| []).filter((r) => r.project_id === p.id),
+      criativos:    (criativosData|| []).filter((r) => r.project_id === p.id),
+      googleAds:    (googleAdsData|| []).filter((r) => r.project_id === p.id),
+      landingPages: (lpData       || []).filter((r) => r.project_id === p.id),
+      bancoMidia:   (bancoData    || []).find ((r) => r.project_id === p.id) ?? null,
+      estrategia:   (estrategiaData || []).find((r) => r.project_id === p.id) ?? null,
+      estrategiaV2: (ev2Data      || []).find ((r) => r.project_id === p.id) ?? null,
+      attachments:  (attachmentsData || []).filter((r) => r.project_id === p.id),
+      resultados:   (resultadosData  || []).filter((r) => r.project_id === p.id),
+    }),
+  );
+}
+
+// ─── Mapeamento patch → coluna projects_v2 ────────────────────────────────────
+const PROJECT_FIELD_MAP = {
+  // camelCase → snake_case
+  companyName:         "company_name",
+  businessType:        "business_type",
+  segmento:            "segmento",
+  responsibleName:     "responsible_name",
+  responsibleRole:     "responsible_role",
+  contractModel:       "contract_model",
+  contractPaymentType: "contract_payment_type",
+  contractValue:       "contract_value",
+  contractDate:        "contract_date",
+  competitors:         "competitors",
+  hasSalesTeam:        "has_sales_team",
+  digitalMaturity:     "digital_maturity",
+  upsellPotential:     "upsell_potential",
+  upsellNotes:         "upsell_notes",
+  otherPeople:         "other_people",
+  services:            "services",
+  servicesData:        "services_data",
+  raioXFileName:       "raio_x_file_url",
+  slaFileName:         "sla_file_url",
+  status:              "status",
+  completedSteps:      "completed_steps",
+  // snake_case passthrough (quando NewOnboarding já envia snake_case)
+  company_name:         "company_name",
+  business_type:        "business_type",
+  responsible_name:     "responsible_name",
+  responsible_role:     "responsible_role",
+  contract_model:       "contract_model",
+  contract_payment_type:"contract_payment_type",
+  contract_value:       "contract_value",
+  contract_date:        "contract_date",
+  has_sales_team:       "has_sales_team",
+  digital_maturity:     "digital_maturity",
+  upsell_potential:     "upsell_potential",
+  upsell_notes:         "upsell_notes",
+  other_people:         "other_people",
+  services_data:        "services_data",
+  raio_x_file_url:      "raio_x_file_url",
+  sla_file_url:         "sla_file_url",
+  completed_steps:      "completed_steps",
+  account_id:           "account_id",
+};
+
+// ─── Supabase: update roteado por tabela ──────────────────────────────────────
+async function sbUpdateProjectV2(id, patch) {
+  if (!supabase) return;
+
+  // ── 1. Campos da tabela projects_v2 ────────────────────────────────────────
+  const projectCols = {};
+  for (const [key, val] of Object.entries(patch)) {
+    if (PROJECT_FIELD_MAP[key]) projectCols[PROJECT_FIELD_MAP[key]] = val;
   }
-  return data.map((row) => ({ ...row.data, id: row.id }));
+  // progress é derivado — não persiste
+  if (Object.keys(projectCols).length > 0) {
+    const { error } = await supabase.from("projects_v2").update(projectCols).eq("id", id);
+    if (error) console.error("[Supabase] update projects_v2:", error.message);
+  }
+
+  // ── 2. ROI Calculator ────────────────────────────────────────────────────
+  if (patch.roiCalc !== undefined) {
+    const roi = patch.roiCalc || {};
+    const roiId = roi.id || crypto.randomUUID();
+    const { error } = await supabase.from("roi_calculators").upsert({
+      id:             roiId,
+      project_id:     id,
+      name:           roi.name           || "Principal",
+      media_orcamento:roi.mediaOrcamento  ?? roi.media_orcamento  ?? null,
+      custo_marketing:roi.custoMarketing  ?? roi.custo_marketing  ?? null,
+      ticket_medio:   roi.ticketMedio     ?? roi.ticket_medio     ?? null,
+      qtd_compras:    roi.qtdCompras      ?? roi.qtd_compras      ?? null,
+      margem_bruta:   roi.margemBruta     ?? roi.margem_bruta     ?? null,
+      roi_desejado:   roi.roiDesejado     ?? roi.roi_desejado     ?? null,
+      taxa_lead_mql:  roi.taxaLead2MQL    ?? roi.taxaLeadMql     ?? roi.taxa_lead_mql    ?? null,
+      taxa_mql_sql:   roi.taxaMQL2SQL     ?? roi.taxaMqlSql      ?? roi.taxa_mql_sql     ?? null,
+      taxa_sql_venda: roi.taxaSQL2Venda   ?? roi.taxaSqlVenda    ?? roi.taxa_sql_venda   ?? null,
+      benchmark_type: roi.benchmarkType   ?? roi.benchmark_type   ?? null,
+      result:         patch.roiResult     ?? roi.result           ?? null,
+    }, { onConflict: "id" });
+    if (error) console.error("[Supabase] upsert roi_calculators:", error.message);
+  }
+
+  // ── 3. Personas ─────────────────────────────────────────────────────────
+  if (patch.personas !== undefined) {
+    await supabase.from("personas").delete().eq("project_id", id);
+    if (Array.isArray(patch.personas) && patch.personas.length > 0) {
+      const { error } = await supabase.from("personas").insert(
+        patch.personas.map((p) => ({
+          id:               p.id || crypto.randomUUID(),
+          project_id:       id,
+          name:             p.name             || "Persona",
+          answers:          p.answers          || {},
+          generated_content:p.generatedProfile  ?? p.generatedContent ?? p.generated_content ?? null,
+          generated_at:     p.generatedAt      ?? p.generated_at      ?? null,
+        })),
+      );
+      if (error) console.error("[Supabase] insert personas:", error.message);
+    }
+  }
+
+  // ── 4. Oferta ────────────────────────────────────────────────────────────
+  if (patch.ofertaData !== undefined) {
+    const oferta = patch.ofertaData || {};
+    const { error } = await supabase.from("ofertas").upsert({
+      id:               oferta.id || crypto.randomUUID(),
+      project_id:       id,
+      answers:          oferta.answers || oferta,
+      generated_content:oferta.generatedOffer ?? oferta.generatedContent ?? oferta.generated_content ?? null,
+      generated_at:     oferta.generatedAt    ?? oferta.generated_at    ?? null,
+    }, { onConflict: "project_id" });
+    if (error) console.error("[Supabase] upsert ofertas:", error.message);
+  }
+
+  // ── 5. Campaign plan ─────────────────────────────────────────────────────
+  if (patch.campaignPlan !== undefined) {
+    const plan = patch.campaignPlan || {};
+    const { error } = await supabase.from("campaign_plans").upsert({
+      id:         plan.id || crypto.randomUUID(),
+      project_id: id,
+      name:       plan.name    || "Principal",
+      answers:    plan.answers || plan,
+    }, { onConflict: "id" });
+    if (error) console.error("[Supabase] upsert campaign_plans:", error.message);
+  }
+
+  // ── 6. Criativos ─────────────────────────────────────────────────────────
+  if (patch.creatives !== undefined) {
+    await supabase.from("criativos").delete().eq("project_id", id);
+    if (Array.isArray(patch.creatives) && patch.creatives.length > 0) {
+      const { error } = await supabase.from("criativos").insert(
+        patch.creatives.map((c) => ({
+          id:               c.id || crypto.randomUUID(),
+          project_id:       id,
+          answers:          { adTypeLabels: c.adTypeLabels, quantity: c.quantity, customNote: c.customNote, isVideo: c.isVideo },
+          generated_content:c.content       ?? null,
+          rating:           c.rating        ?? null,
+          generated_at:     c.createdAt     ?? null,
+        })),
+      );
+      if (error) console.error("[Supabase] insert criativos:", error.message);
+    }
+  }
+
+  // ── 7. Google Ads ────────────────────────────────────────────────────────
+  if (patch.googleAds !== undefined) {
+    await supabase.from("google_ads").delete().eq("project_id", id);
+    if (Array.isArray(patch.googleAds) && patch.googleAds.length > 0) {
+      const { error } = await supabase.from("google_ads").insert(
+        patch.googleAds.map((g) => ({
+          id:               g.id || crypto.randomUUID(),
+          project_id:       id,
+          answers:          { campaignTypes: g.campaignTypes, keywords: g.keywords, city: g.city },
+          generated_content:g.content    ?? null,
+          rating:           g.rating     ?? null,
+          generated_at:     g.createdAt  ?? null,
+        })),
+      );
+      if (error) console.error("[Supabase] insert google_ads:", error.message);
+    }
+  }
+
+  // ── 8. Landing Pages ─────────────────────────────────────────────────────
+  if (patch.landingPages !== undefined) {
+    await supabase.from("landing_pages").delete().eq("project_id", id);
+    if (Array.isArray(patch.landingPages) && patch.landingPages.length > 0) {
+      const { error } = await supabase.from("landing_pages").insert(
+        patch.landingPages.map((lp) => ({
+          id:               lp.id || crypto.randomUUID(),
+          project_id:       id,
+          generated_content:lp.content     ?? lp.generatedContent ?? null,
+          rating:           lp.rating      ?? null,
+          generated_at:     lp.createdAt   ?? lp.generated_at     ?? null,
+        })),
+      );
+      if (error) console.error("[Supabase] insert landing_pages:", error.message);
+    }
+  }
+
+  // ── 9. Banco de Mídia ────────────────────────────────────────────────────
+  const bmFields = {};
+  if (patch.brandFotos  !== undefined) bmFields.photos = patch.brandFotos;
+  if (patch.brandVideos !== undefined) bmFields.videos = patch.brandVideos;
+  if (patch.brandKit) {
+    const kit = patch.brandKit;
+    if (kit.cores           !== undefined) bmFields.color_palette   = kit.cores;
+    if (kit.logo            !== undefined) bmFields.logo_url        = kit.logo;
+    if (kit.fontePrincipal  !== undefined) bmFields.fonte_principal = kit.fontePrincipal;
+    if (kit.fonteSecundaria !== undefined) bmFields.fonte_secundaria= kit.fonteSecundaria;
+    if (kit.fonteObs        !== undefined) bmFields.fonte_obs       = kit.fonteObs;
+  }
+  if (patch.observacoesMidia !== undefined) bmFields.observacoes = patch.observacoesMidia;
+  if (Object.keys(bmFields).length > 0) {
+    const { error } = await supabase.from("banco_midia").upsert(
+      { project_id: id, ...bmFields },
+      { onConflict: "project_id" },
+    );
+    if (error) console.error("[Supabase] upsert banco_midia:", error.message);
+  }
+
+  // ── 10. Estratégia ───────────────────────────────────────────────────────
+  if (patch.estrategia !== undefined) {
+    const narrativa = typeof patch.estrategia === "string"
+      ? patch.estrategia
+      : patch.estrategia?.narrativa ?? null;
+    const { error } = await supabase.from("estrategia").upsert(
+      { project_id: id, narrativa, generated_at: new Date().toISOString() },
+      { onConflict: "project_id" },
+    );
+    if (error) console.error("[Supabase] upsert estrategia:", error.message);
+  }
+
+  // ── 11. Estratégia V2 ────────────────────────────────────────────────────
+  if (patch.estrategiaV2 !== undefined) {
+    const ev2 = patch.estrategiaV2 || {};
+    const { error } = await supabase.from("estrategia_v2").upsert(
+      {
+        project_id:  id,
+        problemas:   ev2.problemas    || [],
+        swot:        ev2.swot         || {},
+        concorrentes:ev2.concorrentes || [],
+        riscos:      ev2.riscos       || [],
+        funis:       ev2.funis        || [],
+      },
+      { onConflict: "project_id" },
+    );
+    if (error) console.error("[Supabase] upsert estrategia_v2:", error.message);
+  }
+
+  // ── 12. Resultados ───────────────────────────────────────────────────────────
+  if (patch.resultados !== undefined) {
+    const { error } = await supabase.from("resultados").upsert(
+      { project_id: id, period: "1900-01-01", data: patch.resultados },
+      { onConflict: "project_id,period" },
+    );
+    if (error) console.error("[Supabase] upsert resultados:", error.message);
+  }
+
+  // ── 13. Attachments (base64 por enquanto; storage_path nullable até Phase 5) ──
+  if (patch.attachments !== undefined) {
+    await supabase.from("attachments").delete().eq("project_id", id);
+    if (Array.isArray(patch.attachments) && patch.attachments.length > 0) {
+      const rows = patch.attachments
+        .filter((a) => a.name && a.size && a.type)
+        .map((a) => ({
+          id:           a.id || crypto.randomUUID(),
+          project_id:   id,
+          name:         a.name,
+          size:         a.size,
+          type:         a.type,
+          storage_path: a.storage_path ?? null, // null até migração para Storage
+        }));
+      if (rows.length > 0) {
+        const { error } = await supabase.from("attachments").insert(rows);
+        if (error) console.error("[Supabase] insert attachments:", error.message);
+      }
+    }
+  }
+
+  // ── 13. Resultados (TODO Phase 5: ResultadosModule devolverá array de rows) ──
+  // Por enquanto não persiste: a estrutura legada (nested object) não mapeia
+  // diretamente para a tabela normalizada. Será tratado em Phase 5.
 }
 
-async function sbUpsert(project) {
+async function sbDeleteProject(id) {
   if (!supabase) return;
-  const { error } = await supabase.from("projects").upsert({
-    id: project.id,
-    data: project,
-    updated_at: new Date().toISOString(),
-  });
-  if (error) console.error("[Supabase] upsert:", error.message);
-}
-
-async function sbDelete(id) {
-  if (!supabase) return;
-  const { error } = await supabase.from("projects").delete().eq("id", id);
-  if (error) console.error("[Supabase] delete:", error.message);
+  const { error } = await supabase.from("projects_v2").delete().eq("id", id);
+  if (error) console.error("[Supabase] delete projects_v2:", error.message);
 }
 
 async function syncProfileIfExists(authUser) {
@@ -61,7 +497,7 @@ async function syncProfileIfExists(authUser) {
     .eq("id", authUser.id)
     .maybeSingle();
   if (error) { console.error("[Supabase] profile check:", error.message); return false; }
-  if (!data) return false; // usuário não cadastrado
+  if (!data) return false;
   const profile = enrichUser(authUser);
   await supabase.from("profiles").update({
     name:   profile.name,
@@ -74,45 +510,35 @@ async function syncProfileIfExists(authUser) {
 // ─── Provider ─────────────────────────────────────────────────────────────────
 export function AppProvider({ children }) {
   // ── Auth ──────────────────────────────────────────────────────────────────
-  const [user, setUser] = useState(null);
+  const [user, setUser]             = useState(null);
   const [loadingAuth, setLoadingAuth] = useState(true);
-  const [authError, setAuthError] = useState(null);
+  const [authError, setAuthError]   = useState(null);
 
   // ── Projects ──────────────────────────────────────────────────────────────
   const [projects, setProjects] = useState(() => {
     try {
-      const s = localStorage.getItem("rl_projects");
+      const s = localStorage.getItem("rl_projects_v2");
       return s ? JSON.parse(s) : [];
-    } catch {
-      return [];
-    }
+    } catch { return []; }
   });
 
   const [loadingProjects, setLoadingProjects] = useState(isSupabaseReady);
-
-  // ── Contador de escritas locais em andamento (evita sobrescrever via realtime) ──
   const pendingWrites = useRef(0);
+  const upsertTimers  = useRef({});
 
-  // ── Debounce timers por projeto (evita múltiplos upserts em edições rápidas) ──
-  const upsertTimers = useRef({});
-
-  // ── Team members (from profiles table) ────────────────────────────────────
+  // ── Team members ──────────────────────────────────────────────────────────
   const [teamMembers, setTeamMembers] = useState([]);
 
-  // ── Supabase Auth session restore + listener ───────────────────────────────
+  // ── Auth session restore + listener ───────────────────────────────────────
   useEffect(() => {
     if (!supabase) { setLoadingAuth(false); return; }
 
-    // Restore existing session on mount
     supabase.auth.getSession().then(({ data: { session } }) => {
       setUser(enrichUser(session?.user ?? null));
       setLoadingAuth(false);
     });
 
-    // Keep user in sync (login, logout, token refresh, cross-tab)
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, session) => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === "SIGNED_IN" && session?.user) {
         syncProfileIfExists(session.user).then((exists) => {
           if (!exists) {
@@ -139,69 +565,77 @@ export function AppProvider({ children }) {
       .then((rows) => {
         if (rows !== null) {
           setProjects(rows);
-          localStorage.setItem("rl_projects", JSON.stringify(rows));
+          localStorage.setItem("rl_projects_v2", JSON.stringify(rows));
         }
       })
-      .catch((err) => {
-        console.error("Erro ao carregar projetos:", err);
-      })
-      .finally(() => {
-        setLoadingProjects(false);
-      });
+      .catch((err) => console.error("Erro ao carregar projetos:", err))
+      .finally(() => setLoadingProjects(false));
 
-    // Load team members from profiles table
     supabase
       .from("profiles")
       .select("*")
       .eq("disabled", false)
       .then(({ data, error }) => {
-        if (error) {
-          console.error("Erro ao carregar membros do time:", error);
-          return;
-        }
+        if (error) { console.error("Erro ao carregar membros:", error); return; }
         if (data) setTeamMembers(data);
       });
   }, []);
 
-  // ── Real-time subscription ─────────────────────────────────────────────────
+  // ── Real-time subscription (projects_v2) ──────────────────────────────────
   useEffect(() => {
     if (!supabase) return;
     const channel = supabase
-      .channel("projects-realtime")
+      .channel("projects-v2-realtime")
       .on(
         "postgres_changes",
-        { event: "INSERT", schema: "public", table: "projects" },
+        { event: "INSERT", schema: "public", table: "projects_v2" },
         ({ new: row }) => {
           if (pendingWrites.current > 0) return;
-          const project = { ...row.data, id: row.id };
+          const project = assembleProject(row);
           setProjects((prev) => {
             const updated = [project, ...prev];
-            localStorage.setItem("rl_projects", JSON.stringify(updated));
+            localStorage.setItem("rl_projects_v2", JSON.stringify(updated));
             return updated;
           });
         },
       )
       .on(
         "postgres_changes",
-        { event: "UPDATE", schema: "public", table: "projects" },
+        { event: "UPDATE", schema: "public", table: "projects_v2" },
         ({ new: row }) => {
           if (pendingWrites.current > 0) return;
-          const project = { ...row.data, id: row.id };
           setProjects((prev) => {
-            const updated = prev.map((p) => (String(p.id) === String(row.id) ? project : p));
-            localStorage.setItem("rl_projects", JSON.stringify(updated));
+            const updated = prev.map((p) => {
+              if (p.id !== row.id) return p;
+              // Preservar relações que não vêm do realtime
+              return assembleProject(row, {
+                rois:        p.roiCalc ? [{ ...p.roiCalc, result: p.roiResult }] : [],
+                personas:    p.personas    || [],
+                ofertas:     p.ofertaData  ? [p.ofertaData] : [],
+                campaigns:   p.campaignPlan? [p.campaignPlan] : [],
+                criativos:   p.creatives   || [],
+                googleAds:   p.googleAds   || [],
+                landingPages:p.landingPages|| [],
+                bancoMidia:  p.bancoMidia  || null,
+                estrategia:  p.estrategia ? { narrativa: p.estrategia.narrativa } : null,
+                estrategiaV2:p.estrategiaV2|| null,
+                attachments: p.attachments || [],
+                resultados:  p.resultados  || [],
+              });
+            });
+            localStorage.setItem("rl_projects_v2", JSON.stringify(updated));
             return updated;
           });
         },
       )
       .on(
         "postgres_changes",
-        { event: "DELETE", schema: "public", table: "projects" },
+        { event: "DELETE", schema: "public", table: "projects_v2" },
         ({ old: row }) => {
           if (pendingWrites.current > 0) return;
           setProjects((prev) => {
-            const updated = prev.filter((p) => String(p.id) !== String(row.id));
-            localStorage.setItem("rl_projects", JSON.stringify(updated));
+            const updated = prev.filter((p) => p.id !== row.id);
+            localStorage.setItem("rl_projects_v2", JSON.stringify(updated));
             return updated;
           });
         },
@@ -213,19 +647,13 @@ export function AppProvider({ children }) {
   // ── Auth actions ──────────────────────────────────────────────────────────
   const login = useCallback(async (email, password) => {
     if (!supabase) return { ok: false, error: "Supabase não configurado." };
-    const { data, error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
     if (error) return { ok: false, error: error.message };
     return { ok: true, user: enrichUser(data.user) };
   }, []);
 
   const logout = useCallback(async () => {
-    if (supabase) {
-      await supabase.auth.signOut();
-      // onAuthStateChange will call setUser(null)
-    }
+    if (supabase) await supabase.auth.signOut();
   }, []);
 
   const loginWithGoogle = useCallback(async () => {
@@ -241,25 +669,53 @@ export function AppProvider({ children }) {
   // ── CRUD ──────────────────────────────────────────────────────────────────
   const addProject = useCallback(
     (data) => {
-      const project = {
-        ...data,
-        id: Date.now(),
-        createdAt: new Date().toISOString(),
-        status: "onboarding",
-        progress: 0,
-        accountId: user?.id,
-        accountName: user?.name,
-        completedSteps: [],
+      const id  = crypto.randomUUID();
+      const now = new Date().toISOString();
+
+      // Aceita tanto snake_case (NewOnboarding atualizado) quanto camelCase (legado)
+      const row = {
+        id,
+        legacy_id:             null,
+        company_name:          data.company_name          ?? data.companyName          ?? "",
+        cnpj:                  data.cnpj                  ?? null,
+        business_type:         data.business_type         ?? data.businessType         ?? "",
+        segmento:              data.segmento              ?? null,
+        responsible_name:      data.responsible_name      ?? data.responsibleName      ?? "",
+        responsible_role:      data.responsible_role      ?? data.responsibleRole      ?? null,
+        contract_model:        data.contract_model        ?? data.contractModel        ?? "",
+        contract_payment_type: data.contract_payment_type ?? data.contractPaymentType  ?? null,
+        contract_value:        data.contract_value        ?? data.contractValue        ?? null,
+        contract_date:         data.contract_date         ?? data.contractDate         ?? null,
+        competitors:           data.competitors           ?? [],
+        has_sales_team:        data.has_sales_team        ?? data.hasSalesTeam         ?? null,
+        digital_maturity:      data.digital_maturity      ?? data.digitalMaturity      ?? null,
+        upsell_potential:      data.upsell_potential      ?? data.upsellPotential      ?? null,
+        upsell_notes:          data.upsell_notes          ?? data.upsellNotes          ?? null,
+        other_people:          data.other_people          ?? data.otherPeople          ?? [],
+        services:              data.services              ?? [],
+        services_data:         data.services_data         ?? data.servicesData         ?? null,
+        raio_x_file_url:       data.raio_x_file_url       ?? data.raioXFileName        ?? null,
+        sla_file_url:          data.sla_file_url          ?? data.slaFileName          ?? null,
+        account_id:            user?.id,
+        status:                "onboarding",
+        completed_steps:       [],
+        created_at:            now,
+        updated_at:            now,
       };
+
+      const project = assembleProject(row);
+
       setProjects((prev) => {
         const updated = [project, ...prev];
-        localStorage.setItem("rl_projects", JSON.stringify(updated));
+        localStorage.setItem("rl_projects_v2", JSON.stringify(updated));
         return updated;
       });
+
       pendingWrites.current += 1;
-      sbUpsert(project)
-        .catch((err) => console.error("Erro ao salvar projeto no Supabase:", err))
+      supabase?.from("projects_v2").insert(row)
+        .then(({ error }) => { if (error) console.error("[Supabase] addProject:", error.message); })
         .finally(() => { pendingWrites.current -= 1; });
+
       return project;
     },
     [user],
@@ -267,18 +723,28 @@ export function AppProvider({ children }) {
 
   const updateProject = useCallback((id, patch) => {
     setProjects((prev) => {
-      const updated = prev.map((p) => (p.id !== id ? p : { ...p, ...patch }));
+      const updated = prev.map((p) => {
+        if (p.id !== id) return p;
+        const merged = { ...p, ...patch };
+        // Sync snake_case ↔ camelCase para campos de projects_v2
+        if (patch.completedSteps !== undefined) merged.completed_steps = patch.completedSteps;
+        if (patch.completed_steps !== undefined) merged.completedSteps = patch.completed_steps;
+        if (patch.status !== undefined) merged.status = patch.status;
+        return merged;
+      });
+
       const merged = updated.find((p) => p.id === id);
       if (merged) {
         clearTimeout(upsertTimers.current[id]);
         upsertTimers.current[id] = setTimeout(() => {
           pendingWrites.current += 1;
-          sbUpsert(merged)
-            .catch((err) => console.error("Erro ao atualizar projeto no Supabase:", err))
+          sbUpdateProjectV2(id, patch)
+            .catch((err) => console.error("Erro ao atualizar:", err))
             .finally(() => { pendingWrites.current -= 1; });
         }, 1000);
       }
-      localStorage.setItem("rl_projects", JSON.stringify(updated));
+
+      localStorage.setItem("rl_projects_v2", JSON.stringify(updated));
       return updated;
     });
   }, []);
@@ -286,10 +752,10 @@ export function AppProvider({ children }) {
   const deleteProject = useCallback((id) => {
     setProjects((prev) => {
       const updated = prev.filter((p) => p.id !== id);
-      localStorage.setItem("rl_projects", JSON.stringify(updated));
+      localStorage.setItem("rl_projects_v2", JSON.stringify(updated));
       return updated;
     });
-    sbDelete(id);
+    sbDeleteProject(id);
   }, []);
 
   // ── Context value ─────────────────────────────────────────────────────────

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -8,3 +8,46 @@ export const supabase = (SUPABASE_URL && SUPABASE_ANON)
   : null
 
 export const isSupabaseReady = !!(SUPABASE_URL && SUPABASE_ANON)
+
+// ─── Storage helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Faz upload de um File para o Supabase Storage e retorna a URL pública/assinada.
+ * @param {string} bucket  - 'project-docs' | 'brand-media' | 'brand-logos' | 'attachments'
+ * @param {string} path    - caminho dentro do bucket, ex: '{projectId}/logo.png'
+ * @param {File}   file    - objeto File do browser
+ * @returns {Promise<string|null>} URL do arquivo ou null em caso de erro
+ */
+export async function uploadFile(bucket, path, file) {
+  if (!supabase) return null
+  const { error } = await supabase.storage.from(bucket).upload(path, file, { upsert: true })
+  if (error) { console.error('[Storage] upload:', error.message); return null }
+  const { data } = supabase.storage.from(bucket).getPublicUrl(path)
+  return data?.publicUrl ?? null
+}
+
+/**
+ * Remove um arquivo do Storage.
+ * @param {string} bucket
+ * @param {string} path
+ */
+export async function deleteFile(bucket, path) {
+  if (!supabase) return
+  const { error } = await supabase.storage.from(bucket).remove([path])
+  if (error) console.error('[Storage] delete:', error.message)
+}
+
+/**
+ * Gera uma URL assinada para download de arquivo privado (válida por 1h).
+ * @param {string} bucket
+ * @param {string} path
+ * @returns {Promise<string|null>}
+ */
+export async function getSignedUrl(bucket, path) {
+  if (!supabase) return null
+  const { data, error } = await supabase.storage
+    .from(bucket)
+    .createSignedUrl(path, 3600)
+  if (error) { console.error('[Storage] signed url:', error.message); return null }
+  return data?.signedUrl ?? null
+}

--- a/src/pages/NewOnboarding.jsx
+++ b/src/pages/NewOnboarding.jsx
@@ -79,9 +79,8 @@ const STEPS = [
   { id: 1, label: 'Empresa',    icon: Building2,  title: 'Dados da Empresa',        sub: 'Informações básicas e segmento do cliente' },
   { id: 2, label: 'Documentos', icon: FileText,   title: 'Documentos',              sub: 'Anexe os arquivos enviados pelo vendedor' },
   { id: 3, label: 'Serviços',   icon: Briefcase,  title: 'Serviços Contratados',    sub: 'Selecione os serviços e configure quantidades' },
-  { id: 4, label: 'Métricas',   icon: DollarSign, title: 'Métricas Financeiras',    sub: 'Ticket médio e verba destinada à mídia paga' },
-  { id: 5, label: 'Contrato',   icon: Calendar,   title: 'Contrato & Concorrência', sub: 'Modelo de contratação, valores e data de assinatura' },
-  { id: 6, label: 'Equipe',     icon: Users,      title: 'Equipe & Potencial',      sub: 'Estrutura interna e oportunidades futuras' },
+  { id: 4, label: 'Contrato',   icon: Calendar,   title: 'Contrato & Concorrência', sub: 'Modelo de contratação, valores e data de assinatura' },
+  { id: 5, label: 'Equipe',     icon: Users,      title: 'Equipe & Potencial',      sub: 'Estrutura interna e oportunidades futuras' },
 ]
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -317,10 +316,7 @@ const initialForm = {
   // Step 3 — Serviços
   services:            [],   // array of service IDs
   servicesData:        {},   // { [serviceId]: { [fieldKey]: value } }
-  // Step 4 — Métricas
-  averageTicket:       '',
-  mediaBudget:         '',
-  // Step 5 — Contrato
+  // Step 4 — Contrato
   contractModel:       '',   // 'aceleracao' | 'assessoria'
   contractPaymentType: '',   // 'unico' | 'mensal'  (only for aceleração)
   contractValue:       '',
@@ -385,16 +381,10 @@ export default function NewOnboarding() {
       if (form.services.length === 0) e.services = 'Selecione ao menos um serviço'
     }
     if (s === 3) {
-      if (form.averageTicket && !parseCurrencyToNumber(form.averageTicket))
-        e.averageTicket = 'Valor inválido — verifique o formato'
-      if (form.mediaBudget && !parseCurrencyToNumber(form.mediaBudget))
-        e.mediaBudget = 'Valor inválido — verifique o formato'
-    }
-    if (s === 4) {
       if (!form.contractModel) e.contractModel = 'Selecione o modelo de contratação'
       if (!form.contractDate)  e.contractDate  = 'Informe a data de assinatura'
     }
-    if (s === 5) {
+    if (s === 4) {
       if (form.hasSalesTeam === null)    e.hasSalesTeam    = 'Informe se tem equipe comercial'
       if (!form.digitalMaturity)         e.digitalMaturity = 'Selecione a maturidade digital'
       if (form.upsellPotential === null) e.upsellPotential = 'Informe o potencial de upsell'
@@ -413,28 +403,26 @@ export default function NewOnboarding() {
       const serviceLabels = form.services.map((id) => SERVICES_CONFIG.find((s) => s.id === id)?.label || id)
 
       const created = addProject({
-        businessType:        form.businessType,
-        companyName:         form.companyName,
-        cnpj:                form.cnpj,
-        responsibleName:     form.responsibleName,
-        responsibleRole:     form.responsibleRole,
-        segmento:            form.segmento,
-        services:            serviceLabels,
-        servicesData:        form.servicesData,
-        contractModel:       form.contractModel,
-        contractPaymentType: form.contractPaymentType,
-        contractValue:       parseCurrencyToNumber(form.contractValue),
-        averageTicket:       parseCurrencyToNumber(form.averageTicket),
-        mediaBudget:         parseCurrencyToNumber(form.mediaBudget),
-        competitors:         form.competitors.filter(Boolean),
-        contractDate:        form.contractDate,
-        hasSalesTeam:        form.hasSalesTeam,
-        digitalMaturity:     form.digitalMaturity,
-        otherPeople:         form.otherPeople.filter((p) => p.name),
-        upsellPotential:     form.upsellPotential,
-        upsellNotes:         form.upsellNotes,
-        raioXFileName:       form.raioXFile?.name ?? null,
-        slaFileName:         form.slaFile?.name ?? null,
+        business_type:         form.businessType,
+        company_name:          form.companyName,
+        cnpj:                  form.cnpj,
+        responsible_name:      form.responsibleName,
+        responsible_role:      form.responsibleRole,
+        segmento:              form.segmento,
+        services:              serviceLabels,
+        services_data:         form.servicesData,
+        contract_model:        form.contractModel,
+        contract_payment_type: form.contractPaymentType,
+        contract_value:        parseCurrencyToNumber(form.contractValue),
+        competitors:           form.competitors.filter(Boolean),
+        contract_date:         form.contractDate,
+        has_sales_team:        form.hasSalesTeam,
+        digital_maturity:      form.digitalMaturity,
+        other_people:          form.otherPeople.filter((p) => p.name),
+        upsell_potential:      form.upsellPotential,
+        upsell_notes:          form.upsellNotes,
+        raio_x_file_url:       form.raioXFile?.name ?? null,
+        sla_file_url:          form.slaFile?.name ?? null,
       })
       clearDraft()
       setCreatedId(created.id)
@@ -717,45 +705,8 @@ export default function NewOnboarding() {
             </div>
           )}
 
-          {/* ─── STEP 4: Métricas Financeiras ──────────────────── */}
+          {/* ─── STEP 4: Contrato & Concorrência ───────────────── */}
           {step === 3 && (
-            <div className="space-y-6">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                  <label className="label-field">Ticket Médio</label>
-                  <div className="relative">
-                    <DollarSign className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-rl-muted" />
-                    <input
-                      value={form.averageTicket}
-                      onChange={(e) => set('averageTicket', formatCurrency(e.target.value))}
-                      placeholder="R$ 0,00"
-                      className={`input-field pl-9 ${errors.averageTicket ? 'border-rl-red' : ''}`}
-                    />
-                  </div>
-                  {errors.averageTicket && <p className="text-rl-red text-xs mt-1">{errors.averageTicket}</p>}
-                </div>
-                <div>
-                  <label className="label-field">Orçamento em Mídia Paga</label>
-                  <div className="relative">
-                    <DollarSign className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-rl-muted" />
-                    <input
-                      value={form.mediaBudget}
-                      onChange={(e) => set('mediaBudget', formatCurrency(e.target.value))}
-                      placeholder="R$ 0,00"
-                      className={`input-field pl-9 ${errors.mediaBudget ? 'border-rl-red' : ''}`}
-                    />
-                  </div>
-                  {errors.mediaBudget && <p className="text-rl-red text-xs mt-1">{errors.mediaBudget}</p>}
-                </div>
-              </div>
-              <p className="text-xs text-rl-muted text-center">
-                Esses valores serão usados na Calculadora de ROI e nos módulos de IA do cliente.
-              </p>
-            </div>
-          )}
-
-          {/* ─── STEP 5: Contrato & Concorrência ───────────────── */}
-          {step === 4 && (
             <div className="space-y-6">
 
               {/* Modelo de Contratação */}
@@ -873,8 +824,8 @@ export default function NewOnboarding() {
             </div>
           )}
 
-          {/* ─── STEP 6: Equipe & Potencial ────────────────────── */}
-          {step === 5 && (
+          {/* ─── STEP 5: Equipe & Potencial ────────────────────── */}
+          {step === 4 && (
             <div className="space-y-6">
 
               {/* Equipe Comercial */}

--- a/supabase/migrations/001_create_projects_v2.sql
+++ b/supabase/migrations/001_create_projects_v2.sql
@@ -1,0 +1,55 @@
+-- Migration 001: Create projects_v2
+-- Tabela normalizada para substituir o JSONB em projects.data
+-- A tabela projects original é preservada intacta durante a migração.
+
+CREATE TABLE projects_v2 (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  legacy_id             TEXT,           -- ID antigo (timestamp string) para rastreabilidade
+  company_name          TEXT NOT NULL,
+  cnpj                  TEXT,
+  business_type         TEXT NOT NULL,
+  segmento              TEXT,
+  responsible_name      TEXT NOT NULL,
+  responsible_role      TEXT,
+  contract_model        TEXT NOT NULL,
+  contract_payment_type TEXT,
+  contract_value        NUMERIC(12,2),
+  contract_date         DATE,
+  competitors           TEXT[],
+  has_sales_team        BOOLEAN,
+  digital_maturity      SMALLINT,
+  upsell_potential      BOOLEAN,
+  upsell_notes          TEXT,
+  other_people          JSONB,
+  services              TEXT[],
+  services_data         JSONB,
+  raio_x_file_url       TEXT,
+  sla_file_url          TEXT,
+  account_id            UUID NOT NULL REFERENCES profiles(id),
+  status                TEXT NOT NULL DEFAULT 'onboarding',
+  completed_steps       TEXT[],
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Trigger para updated_at automático
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER projects_v2_updated_at
+  BEFORE UPDATE ON projects_v2
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- RLS
+ALTER TABLE projects_v2 ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY projects_v2_admin ON projects_v2
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY projects_v2_account ON projects_v2
+  USING (account_id = auth.uid());

--- a/supabase/migrations/002_create_roi_calculators.sql
+++ b/supabase/migrations/002_create_roi_calculators.sql
@@ -1,0 +1,32 @@
+-- Migration 002: Create roi_calculators
+-- Múltiplos cenários de ROI por projeto
+
+CREATE TABLE roi_calculators (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id       UUID NOT NULL REFERENCES projects_v2(id) ON DELETE CASCADE,
+  name             TEXT NOT NULL DEFAULT 'Principal',
+  media_orcamento  NUMERIC(12,2),
+  custo_marketing  NUMERIC(12,2),
+  ticket_medio     NUMERIC(12,2),
+  qtd_compras      SMALLINT,
+  margem_bruta     NUMERIC(5,2),
+  roi_desejado     NUMERIC(6,2),
+  taxa_lead_mql    NUMERIC(5,2),
+  taxa_mql_sql     NUMERIC(5,2),
+  taxa_sql_venda   NUMERIC(5,2),
+  benchmark_type   TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE roi_calculators ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY roi_calculators_admin ON roi_calculators
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY roi_calculators_account ON roi_calculators
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/003_create_personas.sql
+++ b/supabase/migrations/003_create_personas.sql
@@ -1,0 +1,25 @@
+-- Migration 003: Create personas
+-- Personas geradas por IA — múltiplas por projeto
+
+CREATE TABLE personas (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id        UUID NOT NULL REFERENCES projects_v2(id) ON DELETE CASCADE,
+  name              TEXT NOT NULL,
+  answers           JSONB NOT NULL DEFAULT '{}',
+  generated_content TEXT,
+  generated_at      TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE personas ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY personas_admin ON personas
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY personas_account ON personas
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/004_create_ofertas.sql
+++ b/supabase/migrations/004_create_ofertas.sql
@@ -1,0 +1,24 @@
+-- Migration 004: Create ofertas
+-- Oferta matadora gerada por IA — 1:N com projeto (mas tipicamente 1)
+
+CREATE TABLE ofertas (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id        UUID NOT NULL REFERENCES projects_v2(id) ON DELETE CASCADE,
+  answers           JSONB NOT NULL DEFAULT '{}',
+  generated_content TEXT,
+  generated_at      TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE ofertas ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ofertas_admin ON ofertas
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY ofertas_account ON ofertas
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/005_create_campaign_plans.sql
+++ b/supabase/migrations/005_create_campaign_plans.sql
@@ -1,0 +1,23 @@
+-- Migration 005: Create campaign_plans
+-- Planos de campanha — múltiplos por projeto
+
+CREATE TABLE campaign_plans (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects_v2(id) ON DELETE CASCADE,
+  name       TEXT NOT NULL DEFAULT 'Principal',
+  answers    JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE campaign_plans ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY campaign_plans_admin ON campaign_plans
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY campaign_plans_account ON campaign_plans
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/006_create_resultados.sql
+++ b/supabase/migrations/006_create_resultados.sql
@@ -1,0 +1,29 @@
+-- Migration 006: Create resultados
+-- Tracking de métricas semanais/mensais por projeto
+-- Inclui investido e valor_vendas (campos adicionais descobertos no JSONB atual)
+
+CREATE TABLE resultados (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id  UUID NOT NULL REFERENCES projects_v2(id) ON DELETE CASCADE,
+  period      DATE NOT NULL,
+  investido   NUMERIC(12,2),
+  leads       INTEGER,
+  mql         INTEGER,
+  sql         INTEGER,
+  vendas      INTEGER,
+  valor_vendas NUMERIC(12,2),
+  UNIQUE (project_id, period)
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE resultados ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY resultados_admin ON resultados
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY resultados_account ON resultados
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/007_create_criativos.sql
+++ b/supabase/migrations/007_create_criativos.sql
@@ -1,0 +1,25 @@
+-- Migration 007: Create criativos
+-- Criativos de anúncios gerados por IA — múltiplos por projeto
+
+CREATE TABLE criativos (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id        UUID NOT NULL REFERENCES projects_v2(id) ON DELETE CASCADE,
+  answers           JSONB NOT NULL DEFAULT '{}',
+  generated_content TEXT,
+  rating            TEXT,
+  generated_at      TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE criativos ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY criativos_admin ON criativos
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY criativos_account ON criativos
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/008_create_google_ads.sql
+++ b/supabase/migrations/008_create_google_ads.sql
@@ -1,0 +1,25 @@
+-- Migration 008: Create google_ads
+-- Campanhas Google Ads geradas por IA — múltiplos por projeto
+
+CREATE TABLE google_ads (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id        UUID NOT NULL REFERENCES projects_v2(id) ON DELETE CASCADE,
+  answers           JSONB NOT NULL DEFAULT '{}',
+  generated_content TEXT,
+  rating            TEXT,
+  generated_at      TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE google_ads ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY google_ads_admin ON google_ads
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY google_ads_account ON google_ads
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/009_create_landing_pages.sql
+++ b/supabase/migrations/009_create_landing_pages.sql
@@ -1,0 +1,24 @@
+-- Migration 009: Create landing_pages
+-- Landing pages geradas por IA — múltiplos por projeto
+
+CREATE TABLE landing_pages (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id        UUID NOT NULL REFERENCES projects_v2(id) ON DELETE CASCADE,
+  generated_content TEXT,
+  rating            TEXT,
+  generated_at      TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE landing_pages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY landing_pages_admin ON landing_pages
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY landing_pages_account ON landing_pages
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/010_create_banco_midia.sql
+++ b/supabase/migrations/010_create_banco_midia.sql
@@ -1,0 +1,33 @@
+-- Migration 010: Create banco_midia
+-- Biblioteca de marca do projeto — 1:1 com projects_v2
+-- Inclui fonte_principal/secundaria/obs e logo_url (campos adicionais descobertos no JSONB atual)
+
+CREATE TABLE banco_midia (
+  project_id        UUID PRIMARY KEY REFERENCES projects_v2(id) ON DELETE CASCADE,
+  photos            JSONB,
+  videos            JSONB,
+  color_palette     JSONB,
+  logo_url          TEXT,
+  fonte_principal   TEXT,
+  fonte_secundaria  TEXT,
+  fonte_obs         TEXT,
+  observacoes       TEXT,
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER banco_midia_updated_at
+  BEFORE UPDATE ON banco_midia
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- RLS via join com projects_v2
+ALTER TABLE banco_midia ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY banco_midia_admin ON banco_midia
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY banco_midia_account ON banco_midia
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/011_create_estrategia.sql
+++ b/supabase/migrations/011_create_estrategia.sql
@@ -1,0 +1,21 @@
+-- Migration 011: Create estrategia
+-- Narrativa estratégica gerada por IA — 1:1 com projects_v2
+
+CREATE TABLE estrategia (
+  project_id   UUID PRIMARY KEY REFERENCES projects_v2(id) ON DELETE CASCADE,
+  narrativa    TEXT,
+  generated_at TIMESTAMPTZ
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE estrategia ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY estrategia_admin ON estrategia
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY estrategia_account ON estrategia
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/012_create_estrategia_v2.sql
+++ b/supabase/migrations/012_create_estrategia_v2.sql
@@ -1,0 +1,29 @@
+-- Migration 012: Create estrategia_v2
+-- Análise estratégica estruturada com inputs do usuário — 1:1 com projects_v2
+
+CREATE TABLE estrategia_v2 (
+  project_id   UUID PRIMARY KEY REFERENCES projects_v2(id) ON DELETE CASCADE,
+  problemas    TEXT[],
+  swot         JSONB,
+  concorrentes JSONB,
+  riscos       JSONB,
+  funis        TEXT[],
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER estrategia_v2_updated_at
+  BEFORE UPDATE ON estrategia_v2
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- RLS via join com projects_v2
+ALTER TABLE estrategia_v2 ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY estrategia_v2_admin ON estrategia_v2
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY estrategia_v2_account ON estrategia_v2
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/013_create_attachments.sql
+++ b/supabase/migrations/013_create_attachments.sql
@@ -1,0 +1,25 @@
+-- Migration 013: Create attachments
+-- Anexos do projeto — substitui base64 no JSONB; arquivos físicos no Supabase Storage
+
+CREATE TABLE attachments (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id   UUID NOT NULL REFERENCES projects_v2(id) ON DELETE CASCADE,
+  name         TEXT NOT NULL,
+  size         INTEGER NOT NULL,
+  type         TEXT NOT NULL,
+  storage_path TEXT NOT NULL,
+  uploaded_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- RLS via join com projects_v2
+ALTER TABLE attachments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY attachments_admin ON attachments
+  USING (auth.jwt()->'user_metadata'->>'role' = 'admin');
+
+CREATE POLICY attachments_account ON attachments
+  USING (
+    project_id IN (
+      SELECT id FROM projects_v2 WHERE account_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/017_resultados_add_data_jsonb.sql
+++ b/supabase/migrations/017_resultados_add_data_jsonb.sql
@@ -1,0 +1,4 @@
+-- Adiciona coluna JSONB para armazenar o objeto aninhado de resultados
+-- (formato legado: {modelo, b2b: {"YYYY-MM": {semana1: {...}}}, b2c: {...}})
+-- enquanto as colunas flat (leads, mql, etc.) ficam reservadas para Phase 5.
+ALTER TABLE resultados ADD COLUMN IF NOT EXISTS data JSONB;


### PR DESCRIPTION
## Summary

- Reescreve `AppContext` com schema normalizado: `projects_v2` + 13 tabelas filhas (`roi_calculators`, `personas`, `ofertas`, `campaign_plans`, `criativos`, `google_ads`, `landing_pages`, `banco_midia`, `estrategia`, `estrategia_v2`, `attachments`, `resultados`)
- Corrige mapeamento de dados legados (`answers` JSONB → campos planos, `generated_content` → aliases do componente)
- Corrige `brandKit.cores`, logo via signed URL no Storage, download de anexos via Storage
- Adiciona suporte a `resultados` via JSONB (migration 017)
- Adiciona 17 migrations SQL, scripts de migração de dados e documentação (`schema-inputs.md`, `migration-playbook.md`)

## Test plan

- [ ] Criar novo projeto pelo fluxo de onboarding e confirmar rows nas tabelas corretas
- [ ] Abrir projeto existente e verificar que ROI, personas, oferta e planejamento de campanha carregam
- [ ] Verificar cores e logo no módulo de identidade de marca
- [ ] Testar download de anexo migrado (PDF via signed URL)
- [ ] Verificar resultados semanais/mensais no módulo de resultados
- [ ] Checar RLS: usuário account não vê projetos de outros

🤖 Generated with [Claude Code](https://claude.com/claude-code)