### PR TITLE
feat: password reset, dashboard stats por Momento, nav unificada e BancoMídia Storage

### DIFF
--- a/api/admin-users.js
+++ b/api/admin-users.js
@@ -113,5 +113,25 @@ export default async function handler(req) {
     return new Response(text, { status: res.status, headers: { 'content-type': 'application/json' } })
   }
 
+  // ── Redefinir senha ───────────────────────────────────────────────────────
+  if (action === 'reset_password') {
+    if (!userId) return json({ error: 'userId obrigatório.' }, 400)
+    const { password } = data
+    if (!password || password.length < 6) {
+      return json({ error: 'Senha deve ter no mínimo 6 caracteres.' }, 400)
+    }
+    const res = await fetch(`${SUPABASE_URL}/auth/v1/admin/users/${userId}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${SERVICE_KEY}`,
+        apikey: SERVICE_KEY,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ password }),
+    })
+    const text = await res.text()
+    return new Response(text, { status: res.status, headers: { 'content-type': 'application/json' } })
+  }
+
   return json({ error: `Ação desconhecida: ${action}` }, 400)
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import NPSClientForm from './pages/NPSClientForm'
 import BancoDeAnuncios from './pages/BancoDeAnuncios'
 import BancoDeAnunciosPublico from './pages/BancoDeAnunciosPublico'
 import CRMPublico from './pages/CRMPublico'
+import ResetPassword from './pages/ResetPassword'
 
 function RequireAuth({ children }) {
   const { user, loadingAuth } = useApp()
@@ -41,6 +42,7 @@ function AppRoutes() {
         <Route path="/banco-de-anuncios" element={<RequireAuth><BancoDeAnuncios /></RequireAuth>} />
         <Route path="/banco-publico" element={<BancoDeAnunciosPublico />} />
         <Route path="/crm/:token" element={<CRMPublico />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </>

--- a/src/components/AppSidebar.jsx
+++ b/src/components/AppSidebar.jsx
@@ -1,17 +1,20 @@
 import PropTypes from 'prop-types'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useApp } from '../context/AppContext'
-import { Link } from 'react-router-dom'
 import {
-  Zap, Plus, Layers, Clock, CheckCircle2,
+  Zap, Plus, Layers, TrendingDown,
   LogOut, Cloud, CloudOff, Loader2,
-  X, UserCog, BookOpen, Library,
+  X, UserCog, BookOpen, Library, ExternalLink,
 } from 'lucide-react'
 
 const NAV_ITEMS = [
-  { id: 'all',        label: 'Todos os Clientes', Icon: Layers },
-  { id: 'onboarding', label: 'Em Onboarding',    Icon: Clock },
-  { id: 'active',    label: 'Perfis Ativos',      Icon: CheckCircle2 },
+  { id: 'all',      label: 'Clientes',          Icon: Layers,        type: 'filter'   },
+  { id: 'churn',    label: 'Churn',             Icon: TrendingDown,  type: 'filter'   },
+]
+
+const NAV_LINKS = [
+  { id: 'banco',    label: 'Banco de Anúncios', Icon: Library,       type: 'route',    to: '/banco-de-anuncios' },
+  { id: 'playbook', label: 'Playbook',          Icon: BookOpen,      type: 'external', href: 'https://app.clickup.com/9009170774/v/dc/8cfu2ap-40333/8cfu2ap-18173' },
 ]
 
 function SidebarContent({
@@ -59,19 +62,19 @@ function SidebarContent({
       <nav className="space-y-0.5 mb-2">
         {NAV_ITEMS.map(({ id, label, Icon }) => {
           const count = counts?.[id] ?? 0
-          const active = filter === id && location.pathname !== '/users'
+          const active = filter === id && location.pathname === '/'
           return (
             <button
               key={id}
               onClick={() => onNav(id)}
-              className={`w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150 group ${
+              className={`w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150 group border ${
                 active
-                  ? 'bg-rl-purple/15 text-rl-purple border border-rl-purple/25'
-                  : 'text-rl-muted hover:bg-rl-surface hover:text-rl-text border border-transparent'
+                  ? 'bg-rl-purple/15 text-rl-purple border-rl-purple/25'
+                  : 'text-rl-muted hover:bg-rl-surface hover:text-rl-text border-transparent'
               }`}
             >
               <div className="flex items-center gap-2.5">
-                <Icon className={`w-4 h-4 shrink-0 ${active ? 'text-rl-purple' : 'text-rl-muted group-hover:text-rl-text'}`} />
+                <Icon className="w-4 h-4 shrink-0" />
                 {label}
               </div>
               {count > 0 && (
@@ -86,30 +89,39 @@ function SidebarContent({
         })}
       </nav>
 
-      {/* ── Playbook ────────────────────────────────────── */}
-      <a
-        href="https://app.clickup.com/9009170774/v/dc/8cfu2ap-40333/8cfu2ap-18173"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="mx-1 mt-3 flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all duration-150
-          bg-rl-gold/15 border border-rl-gold/40 text-rl-gold
-          hover:bg-rl-gold/25 hover:border-rl-gold/60 hover:shadow-[0_0_12px_rgba(245,176,55,0.25)]"
-      >
-        <BookOpen className="w-4 h-4 shrink-0" />
-        Playbook
-      </a>
+      <div className="border-t border-rl-border/50 mx-1 my-2" />
 
-      {/* ── Banco de Anúncios ────────────────────────────── */}
-      <Link
-        to="/banco-de-anuncios"
-        onClick={onClose}
-        className="mx-1 mt-2 flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all duration-150
-          bg-rl-cyan/10 border border-rl-cyan/30 text-rl-cyan
-          hover:bg-rl-cyan/20 hover:border-rl-cyan/50 hover:shadow-[0_0_12px_rgba(0,210,210,0.2)]"
-      >
-        <Library className="w-4 h-4 shrink-0" />
-        Banco de Anúncios
-      </Link>
+      <nav className="space-y-0.5">
+        {NAV_LINKS.map(({ id, label, Icon, type, to, href }) => {
+          const active = type === 'route' && location.pathname === to
+          const baseClass = `w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150 group border ${
+            active
+              ? 'bg-rl-purple/15 text-rl-purple border-rl-purple/25'
+              : 'text-rl-muted hover:bg-rl-surface hover:text-rl-text border-transparent'
+          }`
+          const content = (
+            <>
+              <div className="flex items-center gap-2.5">
+                <Icon className="w-4 h-4 shrink-0" />
+                {label}
+              </div>
+              {type === 'external' && <ExternalLink className="w-3.5 h-3.5 shrink-0 opacity-50" />}
+            </>
+          )
+          if (type === 'external') {
+            return (
+              <a key={id} href={href} target="_blank" rel="noopener noreferrer" className={baseClass}>
+                {content}
+              </a>
+            )
+          }
+          return (
+            <button key={id} onClick={() => { navigate(to); onClose() }} className={baseClass}>
+              {content}
+            </button>
+          )
+        })}
+      </nav>
 
       {/* ── Spacer ──────────────────────────────────────── */}
       <div className="flex-1" />

--- a/src/components/BancoMidiaModule.jsx
+++ b/src/components/BancoMidiaModule.jsx
@@ -1,18 +1,20 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { useApp } from '../context/AppContext'
-import { getSignedUrl } from '../lib/supabase'
+import { supabase, getSignedUrl, deleteFile } from '../lib/supabase'
 import {
   Upload, Download, Trash2, AlertCircle, Plus, X,
-  Image, Film, Palette, Type, AlertTriangle, Camera,
+  Image, Film, Palette, Type, AlertTriangle, Camera, Loader2,
 } from 'lucide-react'
 
 // ─── Limits ───────────────────────────────────────────────────────────────────
-const PHOTO_MAX_MB  = 8
-const VIDEO_MAX_MB  = 50
-const TOTAL_MAX_MB  = 100
-const PHOTO_MAX     = PHOTO_MAX_MB * 1024 * 1024
-const VIDEO_MAX     = VIDEO_MAX_MB * 1024 * 1024
-const TOTAL_MAX     = TOTAL_MAX_MB * 1024 * 1024
+const PHOTO_MAX_MB = 8
+const VIDEO_MAX_MB = 50
+const TOTAL_MAX_MB = 100
+const PHOTO_MAX    = PHOTO_MAX_MB * 1024 * 1024
+const VIDEO_MAX    = VIDEO_MAX_MB * 1024 * 1024
+const TOTAL_MAX    = TOTAL_MAX_MB * 1024 * 1024
+const MEDIA_BUCKET = 'brand-media'
+const LOGO_BUCKET  = 'brand-logos'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 function fmtSize(bytes) {
@@ -20,21 +22,32 @@ function fmtSize(bytes) {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 
-function readFileAsBase64(file) {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload  = (e) => resolve(e.target.result)
-    reader.onerror = () => reject(new Error('Erro ao ler arquivo'))
-    reader.readAsDataURL(file)
-  })
+async function storageUpload(bucket, path, file) {
+  if (!supabase) return null
+  const { error } = await supabase.storage.from(bucket).upload(path, file, { upsert: true })
+  if (error) { console.error('[Storage] upload:', error.message); return null }
+  return path
+}
+
+async function downloadFromUrl(url, name) {
+  try {
+    const res  = await fetch(url)
+    const blob = await res.blob()
+    const href = URL.createObjectURL(blob)
+    const a    = document.createElement('a')
+    a.href = href; a.download = name
+    document.body.appendChild(a); a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(href)
+  } catch {
+    window.open(url, '_blank')
+  }
 }
 
 function triggerDownload(data, name) {
   const a = document.createElement('a')
-  a.href     = data
-  a.download = name
-  document.body.appendChild(a)
-  a.click()
+  a.href = data; a.download = name
+  document.body.appendChild(a); a.click()
   document.body.removeChild(a)
 }
 
@@ -42,10 +55,7 @@ function triggerDownload(data, name) {
 function ColorChip({ color, onDelete }) {
   return (
     <div className="group flex items-center gap-2 bg-rl-surface border border-rl-border rounded-xl px-3 py-2">
-      <div
-        className="w-6 h-6 rounded-lg border border-black/10 shrink-0"
-        style={{ backgroundColor: color.hex }}
-      />
+      <div className="w-6 h-6 rounded-lg border border-black/10 shrink-0" style={{ backgroundColor: color.hex }} />
       <div className="min-w-0">
         <p className="text-xs font-semibold text-rl-text">{color.hex.toUpperCase()}</p>
         {color.nome && <p className="text-[10px] text-rl-muted truncate">{color.nome}</p>}
@@ -62,110 +72,133 @@ function ColorChip({ color, onDelete }) {
 }
 
 // ─── Photo Grid ───────────────────────────────────────────────────────────────
-function PhotoGrid({ fotos, onDelete }) {
+function PhotoGrid({ fotos, urlMap, onDelete }) {
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-      {fotos.map((f) => (
-        <div key={f.id} className="group relative aspect-square rounded-xl overflow-hidden border border-rl-border bg-rl-surface">
-          <img src={f.data} alt={f.name} className="w-full h-full object-cover" />
-          {/* Hover overlay */}
-          <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
-            <button
-              onClick={() => triggerDownload(f.data, f.name)}
-              className="p-2 rounded-lg bg-white/20 hover:bg-white/30 text-white transition-all"
-              title="Baixar"
-            >
-              <Download className="w-4 h-4" />
-            </button>
-            <button
-              onClick={() => onDelete(f.id)}
-              className="p-2 rounded-lg bg-red-500/60 hover:bg-red-500/80 text-white transition-all"
-              title="Remover"
-            >
-              <Trash2 className="w-4 h-4" />
-            </button>
-          </div>
-          {/* Filename on bottom */}
-          <div className="absolute bottom-0 inset-x-0 bg-black/40 px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity">
-            <p className="text-[10px] text-white truncate">{f.name}</p>
-          </div>
-        </div>
-      ))}
-    </div>
-  )
-}
-
-// ─── Video List ───────────────────────────────────────────────────────────────
-function VideoList({ videos, onDelete }) {
-  const [playing, setPlaying] = useState(null)
-
-  return (
-    <div className="space-y-3">
-      {videos.map((v) => (
-        <div key={v.id} className="glass-card overflow-hidden">
-          {playing === v.id && (
-            <video
-              src={v.data}
-              controls
-              autoPlay
-              className="w-full max-h-48 bg-black"
-              onEnded={() => setPlaying(null)}
-            />
-          )}
-          <div className="flex items-center gap-3 p-3">
-            <div className="w-10 h-10 rounded-xl bg-rl-purple/10 flex items-center justify-center shrink-0">
-              <Film className="w-5 h-5 text-rl-purple" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-rl-text truncate">{v.name}</p>
-              <p className="text-xs text-rl-muted">{fmtSize(v.size)}</p>
-            </div>
-            <div className="flex items-center gap-1 shrink-0">
+      {fotos.map((f) => {
+        const src = urlMap[f.id] || f.data || null
+        return (
+          <div key={f.id} className="group relative aspect-square rounded-xl overflow-hidden border border-rl-border bg-rl-surface">
+            {src ? (
+              <img src={src} alt={f.name} className="w-full h-full object-cover" />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center">
+                <Loader2 className="w-5 h-5 animate-spin text-rl-muted" />
+              </div>
+            )}
+            <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
               <button
-                onClick={() => setPlaying(playing === v.id ? null : v.id)}
-                className="px-3 py-1.5 rounded-lg text-xs font-medium bg-rl-purple/10 text-rl-purple hover:bg-rl-purple/20 transition-all"
-              >
-                {playing === v.id ? 'Fechar' : 'Preview'}
-              </button>
-              <button
-                onClick={() => triggerDownload(v.data, v.name)}
-                className="p-1.5 rounded-lg text-rl-muted hover:text-rl-purple hover:bg-rl-purple/10 transition-all"
+                onClick={() => src ? downloadFromUrl(src, f.name) : null}
+                className="p-2 rounded-lg bg-white/20 hover:bg-white/30 text-white transition-all"
                 title="Baixar"
               >
                 <Download className="w-4 h-4" />
               </button>
               <button
-                onClick={() => onDelete(v.id)}
-                className="p-1.5 rounded-lg text-rl-muted hover:text-rl-red hover:bg-rl-red/10 transition-all"
+                onClick={() => onDelete(f.id)}
+                className="p-2 rounded-lg bg-red-500/60 hover:bg-red-500/80 text-white transition-all"
                 title="Remover"
               >
                 <Trash2 className="w-4 h-4" />
               </button>
             </div>
+            <div className="absolute bottom-0 inset-x-0 bg-black/40 px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity">
+              <p className="text-[10px] text-white truncate">{f.name}</p>
+            </div>
           </div>
-        </div>
-      ))}
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── Video List ───────────────────────────────────────────────────────────────
+function VideoList({ videos, urlMap, onDelete }) {
+  const [playing, setPlaying] = useState(null)
+
+  return (
+    <div className="space-y-3">
+      {videos.map((v) => {
+        const src = urlMap[v.id] || v.data || null
+        return (
+          <div key={v.id} className="glass-card overflow-hidden">
+            {playing === v.id && src && (
+              <video
+                src={src}
+                controls
+                autoPlay
+                className="w-full max-h-48 bg-black"
+                onEnded={() => setPlaying(null)}
+              />
+            )}
+            <div className="flex items-center gap-3 p-3">
+              <div className="w-10 h-10 rounded-xl bg-rl-purple/10 flex items-center justify-center shrink-0">
+                <Film className="w-5 h-5 text-rl-purple" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-rl-text truncate">{v.name}</p>
+                <p className="text-xs text-rl-muted">{fmtSize(v.size)}</p>
+              </div>
+              <div className="flex items-center gap-1 shrink-0">
+                <button
+                  onClick={() => setPlaying(playing === v.id ? null : v.id)}
+                  disabled={!src}
+                  className="px-3 py-1.5 rounded-lg text-xs font-medium bg-rl-purple/10 text-rl-purple hover:bg-rl-purple/20 transition-all disabled:opacity-40"
+                >
+                  {playing === v.id ? 'Fechar' : 'Preview'}
+                </button>
+                <button
+                  onClick={() => src ? downloadFromUrl(src, v.name) : null}
+                  disabled={!src}
+                  className="p-1.5 rounded-lg text-rl-muted hover:text-rl-purple hover:bg-rl-purple/10 transition-all disabled:opacity-40"
+                  title="Baixar"
+                >
+                  <Download className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={() => onDelete(v.id)}
+                  className="p-1.5 rounded-lg text-rl-muted hover:text-rl-red hover:bg-rl-red/10 transition-all"
+                  title="Remover"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          </div>
+        )
+      })}
     </div>
   )
 }
 
 // ─── Upload Zone ──────────────────────────────────────────────────────────────
-function UploadZone({ accept, label, sublabel, onFiles, inputRef }) {
+function UploadZone({ accept, label, sublabel, onFiles, inputRef, uploading }) {
   const [dragging, setDragging] = useState(false)
 
   return (
     <div
-      onClick={() => inputRef.current?.click()}
+      onClick={() => !uploading && inputRef.current?.click()}
       onDragOver={(e) => { e.preventDefault(); setDragging(true) }}
       onDragLeave={() => setDragging(false)}
-      onDrop={(e) => { e.preventDefault(); setDragging(false); onFiles(e.dataTransfer.files) }}
-      className={`rounded-xl border-2 border-dashed p-5 text-center cursor-pointer transition-all duration-200 ${
-        dragging ? 'border-rl-purple bg-rl-purple/10' : 'border-rl-border hover:border-rl-purple/50 hover:bg-rl-purple/5'
+      onDrop={(e) => { e.preventDefault(); setDragging(false); if (!uploading) onFiles(e.dataTransfer.files) }}
+      className={`rounded-xl border-2 border-dashed p-5 text-center transition-all duration-200 ${
+        uploading
+          ? 'border-rl-purple/50 bg-rl-purple/5 cursor-wait'
+          : 'cursor-pointer ' + (dragging ? 'border-rl-purple bg-rl-purple/10' : 'border-rl-border hover:border-rl-purple/50 hover:bg-rl-purple/5')
       }`}
     >
-      <Upload className={`w-5 h-5 mx-auto mb-2 ${dragging ? 'text-rl-purple' : 'text-rl-muted'}`} />
-      <p className="text-xs font-semibold text-rl-text">{label}</p>
-      <p className="text-[11px] text-rl-muted mt-0.5">{sublabel}</p>
+      {uploading ? (
+        <>
+          <Loader2 className="w-5 h-5 mx-auto mb-2 text-rl-purple animate-spin" />
+          <p className="text-xs font-semibold text-rl-purple">Enviando...</p>
+        </>
+      ) : (
+        <>
+          <Upload className={`w-5 h-5 mx-auto mb-2 ${dragging ? 'text-rl-purple' : 'text-rl-muted'}`} />
+          <p className="text-xs font-semibold text-rl-text">{label}</p>
+          <p className="text-[11px] text-rl-muted mt-0.5">{sublabel}</p>
+        </>
+      )}
       <input ref={inputRef} type="file" accept={accept} multiple className="hidden" onChange={(e) => onFiles(e.target.files)} />
     </div>
   )
@@ -179,25 +212,53 @@ export default function BancoMidiaModule({ project }) {
   const photoInputRef = useRef(null)
   const videoInputRef = useRef(null)
 
-  const [error,      setError]      = useState(null)
-  const [newColor,   setNewColor]   = useState({ hex: '#164496', nome: '' })
-  const [showAddColor, setShowAddColor] = useState(false)
-  const [logoSrc,    setLogoSrc]    = useState(null)
+  const [error,         setError]         = useState(null)
+  const [newColor,      setNewColor]      = useState({ hex: '#164496', nome: '' })
+  const [showAddColor,  setShowAddColor]  = useState(false)
+  const [logoSrc,       setLogoSrc]       = useState(null)
+  const [uploadingPhotos, setUploadingPhotos] = useState(false)
+  const [uploadingVideos, setUploadingVideos] = useState(false)
+
+  // URL maps for Storage-backed items { [id]: signedUrl }
+  const [photoUrls, setPhotoUrls] = useState({})
+  const [videoUrls, setVideoUrls] = useState({})
 
   // ── Data shortcuts ──────────────────────────────────────────────────────────
   const kit    = project.brandKit    || {}
   const fotos  = project.brandFotos  || []
   const videos = project.brandVideos || []
 
-  // ── Resolve logo: base64 direto ou signed URL do Storage ───────────────────
+  // ── Resolve logo ────────────────────────────────────────────────────────────
   useEffect(() => {
     if (!kit.logo) { setLogoSrc(null); return }
     if (kit.logo.startsWith('data:') || kit.logo.startsWith('http')) {
       setLogoSrc(kit.logo)
     } else {
-      getSignedUrl('brand-logos', kit.logo).then((url) => setLogoSrc(url))
+      getSignedUrl(LOGO_BUCKET, kit.logo).then((url) => setLogoSrc(url))
     }
   }, [kit.logo])
+
+  // ── Resolve photo URLs ──────────────────────────────────────────────────────
+  useEffect(() => {
+    const storageItems = fotos.filter(f => f.path)
+    if (!storageItems.length) return
+    Promise.all(
+      storageItems.map(f => getSignedUrl(MEDIA_BUCKET, f.path).then(url => [f.id, url]))
+    ).then(entries => {
+      setPhotoUrls(Object.fromEntries(entries.filter(([, url]) => url)))
+    })
+  }, [fotos])
+
+  // ── Resolve video URLs ──────────────────────────────────────────────────────
+  useEffect(() => {
+    const storageItems = videos.filter(v => v.path)
+    if (!storageItems.length) return
+    Promise.all(
+      storageItems.map(v => getSignedUrl(MEDIA_BUCKET, v.path).then(url => [v.id, url]))
+    ).then(entries => {
+      setVideoUrls(Object.fromEntries(entries.filter(([, url]) => url)))
+    })
+  }, [videos])
 
   function saveKit(patch) {
     updateProject(project.id, { brandKit: { ...kit, ...patch } })
@@ -209,8 +270,10 @@ export default function BancoMidiaModule({ project }) {
     if (!file) return
     if (!file.type.startsWith('image/')) { setError('Selecione uma imagem para o logotipo.'); return }
     if (file.size > PHOTO_MAX) { setError(`Logotipo excede ${PHOTO_MAX_MB} MB.`); return }
-    const data = await readFileAsBase64(file)
-    saveKit({ logo: data })
+    const ext  = file.name.split('.').pop()
+    const path = await storageUpload(LOGO_BUCKET, `${project.id}/logo.${ext}`, file)
+    if (!path) { setError('Erro ao enviar logotipo. Tente novamente.'); return }
+    saveKit({ logo: path })
   }
 
   // ── Colors ──────────────────────────────────────────────────────────────────
@@ -230,23 +293,33 @@ export default function BancoMidiaModule({ project }) {
   const handlePhotos = useCallback(async (files) => {
     setError(null)
     if (!files?.length) return
-    const list   = Array.from(files)
-    const result = []
+    const list    = Array.from(files)
     const current = fotos.reduce((s, f) => s + (f.size || 0), 0)
 
     for (const file of list) {
       if (!file.type.startsWith('image/')) { setError(`"${file.name}" não é uma imagem.`); return }
       if (file.size > PHOTO_MAX) { setError(`"${file.name}" excede ${PHOTO_MAX_MB} MB.`); return }
-      const allSize = current + result.reduce((s, f) => s + f.size, 0) + file.size
-      if (allSize > TOTAL_MAX) { setError(`Limite total de ${TOTAL_MAX_MB} MB atingido.`); return }
-      const data = await readFileAsBase64(file)
-      result.push({ id: `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`, name: file.name, size: file.size, type: file.type, data, uploadedAt: new Date().toISOString() })
+      if (current + file.size > TOTAL_MAX) { setError(`Limite total de ${TOTAL_MAX_MB} MB atingido.`); return }
     }
+
+    setUploadingPhotos(true)
+    const result = []
+    for (const file of list) {
+      const id   = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+      const ext  = file.name.split('.').pop()
+      const path = await storageUpload(MEDIA_BUCKET, `${project.id}/photos/${id}.${ext}`, file)
+      if (!path) { setError(`Erro ao enviar "${file.name}".`); setUploadingPhotos(false); return }
+      result.push({ id, name: file.name, size: file.size, type: file.type, path, uploadedAt: new Date().toISOString() })
+    }
+
     updateProject(project.id, { brandFotos: [...fotos, ...result] })
     if (photoInputRef.current) photoInputRef.current.value = ''
+    setUploadingPhotos(false)
   }, [fotos, project.id, updateProject])
 
-  function deletePhoto(id) {
+  async function deletePhoto(id) {
+    const item = fotos.find(f => f.id === id)
+    if (item?.path) await deleteFile(MEDIA_BUCKET, item.path)
     updateProject(project.id, { brandFotos: fotos.filter((f) => f.id !== id) })
   }
 
@@ -254,27 +327,37 @@ export default function BancoMidiaModule({ project }) {
   const handleVideos = useCallback(async (files) => {
     setError(null)
     if (!files?.length) return
-    const list   = Array.from(files)
-    const result = []
+    const list    = Array.from(files)
     const current = videos.reduce((s, v) => s + (v.size || 0), 0)
 
     for (const file of list) {
       if (!file.type.startsWith('video/')) { setError(`"${file.name}" não é um vídeo.`); return }
       if (file.size > VIDEO_MAX) { setError(`"${file.name}" excede ${VIDEO_MAX_MB} MB por vídeo.`); return }
-      const allSize = current + result.reduce((s, v) => s + v.size, 0) + file.size
-      if (allSize > TOTAL_MAX) { setError(`Limite total de ${TOTAL_MAX_MB} MB atingido.`); return }
-      const data = await readFileAsBase64(file)
-      result.push({ id: `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`, name: file.name, size: file.size, type: file.type, data, uploadedAt: new Date().toISOString() })
+      if (current + file.size > TOTAL_MAX) { setError(`Limite total de ${TOTAL_MAX_MB} MB atingido.`); return }
     }
+
+    setUploadingVideos(true)
+    const result = []
+    for (const file of list) {
+      const id   = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+      const ext  = file.name.split('.').pop()
+      const path = await storageUpload(MEDIA_BUCKET, `${project.id}/videos/${id}.${ext}`, file)
+      if (!path) { setError(`Erro ao enviar "${file.name}".`); setUploadingVideos(false); return }
+      result.push({ id, name: file.name, size: file.size, type: file.type, path, uploadedAt: new Date().toISOString() })
+    }
+
     updateProject(project.id, { brandVideos: [...videos, ...result] })
     if (videoInputRef.current) videoInputRef.current.value = ''
+    setUploadingVideos(false)
   }, [videos, project.id, updateProject])
 
-  function deleteVideo(id) {
+  async function deleteVideo(id) {
+    const item = videos.find(v => v.id === id)
+    if (item?.path) await deleteFile(MEDIA_BUCKET, item.path)
     updateProject(project.id, { brandVideos: videos.filter((v) => v.id !== id) })
   }
 
-  // ── Storage calc ────────────────────────────────────────────────────────────
+  // ── Storage bar ─────────────────────────────────────────────────────────────
   const totalUsed = fotos.reduce((s, f) => s + (f.size || 0), 0) + videos.reduce((s, v) => s + (v.size || 0), 0)
   const totalPct  = Math.min(100, (totalUsed / TOTAL_MAX) * 100)
 
@@ -443,11 +526,12 @@ export default function BancoMidiaModule({ project }) {
           sublabel={`PNG, JPG, WebP · Máx. ${PHOTO_MAX_MB} MB por foto`}
           onFiles={handlePhotos}
           inputRef={photoInputRef}
+          uploading={uploadingPhotos}
         />
 
         {fotos.length > 0 && (
           <div className="mt-4">
-            <PhotoGrid fotos={fotos} onDelete={deletePhoto} />
+            <PhotoGrid fotos={fotos} urlMap={photoUrls} onDelete={deletePhoto} />
           </div>
         )}
       </section>
@@ -472,16 +556,17 @@ export default function BancoMidiaModule({ project }) {
           sublabel={`MP4, MOV, WebM · Máx. ${VIDEO_MAX_MB} MB por vídeo`}
           onFiles={handleVideos}
           inputRef={videoInputRef}
+          uploading={uploadingVideos}
         />
 
         {videos.length > 0 && (
           <div className="mt-4">
-            <VideoList videos={videos} onDelete={deleteVideo} />
+            <VideoList videos={videos} urlMap={videoUrls} onDelete={deleteVideo} />
           </div>
         )}
       </section>
 
-      {/* ── 4. Observações / O que evitar ──────────────────────────────────── */}
+      {/* ── 4. O Que Evitar ────────────────────────────────────────────────── */}
       <section>
         <div className="flex items-center gap-2 mb-4">
           <div className="w-8 h-8 rounded-xl bg-rl-red/10 flex items-center justify-center">

--- a/src/pages/BancoDeAnuncios.jsx
+++ b/src/pages/BancoDeAnuncios.jsx
@@ -1,10 +1,13 @@
 import { useState, useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
+import { useApp } from '../context/AppContext'
+import AppSidebar from '../components/AppSidebar'
 import {
   Library, Plus, Image, X, Upload,
   Share2, Loader2, Check, Trash2,
   ChevronDown, Play, Film, Filter,
-  Download, Maximize2,
+  Download, Maximize2, Menu, Zap,
 } from 'lucide-react'
 
 const FUNILS = [
@@ -191,6 +194,13 @@ function UploadZone({ type, file, preview, onSelect, onClear }) {
 }
 
 export default function BancoDeAnuncios() {
+  const navigate = useNavigate()
+  const { squads, teamMembers } = useApp()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  const emptyCounts = { all: 0, churn: 0, squads: {}, risks: {}, momentos: {} }
+  const activeAccounts = teamMembers.filter(m => !m.disabled)
+
   // ── Form state
   const [type,    setType]    = useState('video')
   const [funil,   setFunil]   = useState('')
@@ -302,8 +312,39 @@ export default function BancoDeAnuncios() {
   })
 
   return (
-    <div className="min-h-screen bg-rl-bg">
-      <div className="max-w-6xl mx-auto px-4 py-8 space-y-8">
+    <div className="min-h-screen flex bg-gradient-dark">
+
+      <AppSidebar
+        filter="all"
+        setFilter={() => navigate('/')}
+        counts={emptyCounts}
+        activeAccounts={activeAccounts}
+        squads={squads}
+        open={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+      />
+
+      <div className="flex-1 min-w-0 flex flex-col">
+
+        {/* Mobile top bar */}
+        <div className="lg:hidden sticky top-0 z-40 flex items-center gap-3 px-4 h-14 border-b border-rl-border bg-rl-bg/90 backdrop-blur-xl">
+          <button
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Abrir menu de navegação"
+            className="p-2 rounded-lg text-rl-muted hover:text-rl-text hover:bg-rl-surface transition-all"
+          >
+            <Menu className="w-5 h-5" />
+          </button>
+          <div className="flex items-center gap-2">
+            <div className="w-6 h-6 rounded-md bg-gradient-rl flex items-center justify-center">
+              <Zap className="w-3.5 h-3.5 text-white" />
+            </div>
+            <span className="font-bold text-rl-text text-sm">Banco de Anúncios</span>
+          </div>
+        </div>
+
+        <main className="flex-1 px-6 py-8">
+      <div className="max-w-6xl mx-auto space-y-8">
 
         {/* Header */}
         <div className="flex items-center gap-3">
@@ -498,6 +539,8 @@ export default function BancoDeAnuncios() {
           )}
         </div>
 
+        </div>
+        </main>
       </div>
     </div>
   )

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -121,18 +121,6 @@ function ProjectCard({ project, onClick, onDelete }) {
     ? Math.ceil((new Date(project.contractDate).getTime() - Date.now()) / 86400000)
     : null
 
-  const statusColor = {
-    onboarding: 'text-rl-cyan bg-rl-cyan/10 border-rl-cyan/30',
-    active:     'text-rl-green bg-rl-green/10 border-rl-green/30',
-    paused:     'text-rl-gold bg-rl-gold/10 border-rl-gold/30',
-  }[project.status] || 'text-rl-muted bg-rl-muted/10 border-rl-muted/30'
-
-  const statusLabel = {
-    onboarding: 'Em Onboarding',
-    active:     'Ativo',
-    paused:     'Pausado',
-  }[project.status] || project.status
-
   return (
     <div onClick={onClick} className="glass-card p-5 hover:border-rl-purple/40 transition-all duration-200 cursor-pointer group relative">
       {/* Delete button */}
@@ -146,13 +134,10 @@ function ProjectCard({ project, onClick, onDelete }) {
       </button>
 
       {/* Header */}
-      <div className="flex items-start justify-between mb-1">
-        <h3 className="font-semibold text-rl-text group-hover:text-rl-purple transition-colors leading-tight">
+      <div className="mb-1">
+        <h3 className="font-semibold text-rl-text group-hover:text-rl-purple transition-colors leading-tight pr-8">
           {project.companyName}
         </h3>
-        <span className={`text-xs font-medium px-2.5 py-1 rounded-full border mr-7 shrink-0 ml-2 ${statusColor}`}>
-          {statusLabel}
-        </span>
       </div>
       <p className="text-rl-muted text-xs mb-3">{project.responsibleName}{project.responsibleRole ? ` · ${project.responsibleRole}` : ''}</p>
 
@@ -218,24 +203,19 @@ function ClientProfileCard({ project, onClick, onDelete }) {
       </button>
 
       {/* Header */}
-      <div className="flex items-start justify-between mb-1">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="w-9 h-9 rounded-xl bg-rl-green/10 flex items-center justify-center shrink-0">
-            <FileText className="w-4 h-4 text-rl-green" />
-          </div>
-          <div className="min-w-0">
-            <h3 className="font-semibold text-rl-text group-hover:text-rl-purple transition-colors truncate">
-              {project.companyName}
-            </h3>
-            <p className="text-rl-muted text-xs mt-0.5 truncate">
-              {project.businessType && <span className="mr-1">{project.businessType} ·</span>}
-              {project.responsibleName}
-            </p>
-          </div>
+      <div className="flex items-center gap-3 min-w-0 mb-1">
+        <div className="w-9 h-9 rounded-xl bg-rl-green/10 flex items-center justify-center shrink-0">
+          <FileText className="w-4 h-4 text-rl-green" />
         </div>
-        <span className="text-xs font-medium px-2.5 py-1 rounded-full border text-rl-green bg-rl-green/10 border-rl-green/30 whitespace-nowrap mr-7 shrink-0 ml-2">
-          Perfil Completo
-        </span>
+        <div className="min-w-0 pr-8">
+          <h3 className="font-semibold text-rl-text group-hover:text-rl-purple transition-colors truncate">
+            {project.companyName}
+          </h3>
+          <p className="text-rl-muted text-xs mt-0.5 truncate">
+            {project.businessType && <span className="mr-1">{project.businessType} ·</span>}
+            {project.responsibleName}
+          </p>
+        </div>
       </div>
 
       {/* Squad + Risk + Momento */}
@@ -523,7 +503,6 @@ const LIST_COLS = [
   { key: 'companyName',     label: 'Empresa'             },
   { key: 'squadName',       label: 'Squad'               },
   { key: 'responsibleName', label: 'Responsável / Cargo' },
-  { key: 'status',          label: 'Status'              },
   { key: 'riskLevel',       label: 'Risco'               },
   { key: 'momento',         label: 'Momento'             },
   { key: 'progress',        label: 'Progresso'           },
@@ -531,12 +510,6 @@ const LIST_COLS = [
   { key: 'createdAt',       label: 'Criado em'           },
 ]
 
-const STATUS_LABEL = { onboarding: 'Em Onboarding', active: 'Ativo', paused: 'Pausado' }
-const STATUS_COLOR = {
-  onboarding: 'text-rl-cyan  bg-rl-cyan/10  border-rl-cyan/30',
-  active:     'text-rl-green bg-rl-green/10 border-rl-green/30',
-  paused:     'text-rl-gold  bg-rl-gold/10  border-rl-gold/30',
-}
 
 function SortIcon({ col, sortBy, sortDir }) {
   if (sortBy !== col) return <ChevronsUpDown className="w-3 h-3 text-rl-muted/40" />
@@ -595,11 +568,6 @@ function ProjectListView({ projects, onNavigate, onDelete }) {
           {/* Body */}
           <tbody>
             {sorted.map((p, i) => {
-              const complete = isProfileComplete(p)
-              const statusLabel = complete ? 'Perfil Completo' : (STATUS_LABEL[p.status] || p.status)
-              const statusColor = complete
-                ? 'text-rl-green bg-rl-green/10 border-rl-green/30'
-                : (STATUS_COLOR[p.status] || 'text-rl-muted bg-rl-muted/10 border-rl-muted/30')
               const createdStr = p.createdAt
                 ? new Date(p.createdAt).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' })
                 : '—'
@@ -639,13 +607,6 @@ function ProjectListView({ projects, onNavigate, onDelete }) {
                         </div>
                       : <span className="text-rl-muted">—</span>
                     }
-                  </td>
-
-                  {/* Status */}
-                  <td className="px-4 py-3">
-                    <span className={`text-xs font-medium px-2 py-0.5 rounded-full border whitespace-nowrap ${statusColor}`}>
-                      {statusLabel}
-                    </span>
                   </td>
 
                   {/* Risco */}
@@ -814,13 +775,14 @@ export default function Dashboard() {
   // Apply status/member filter
   const filteredProjects = (() => {
     let result = baseProjects
-    if (filter === 'onboarding')      result = result.filter(p => p.status === 'onboarding')
+    if (filter === 'churn')            result = result.filter(p => p.momento === 'churn')
+    else if (filter === 'onboarding') result = result.filter(p => p.status === 'onboarding')
     else if (filter === 'active')     result = result.filter(p => p.status === 'active')
     else if (filter !== 'all')        result = result.filter(p => String(p.accountId) === String(filter))
     if (squadFilter   !== 'all')      result = result.filter(p => String(p.squad) === String(squadFilter))
     if (riskFilter    !== 'all')      result = result.filter(p => p.riskLevel === riskFilter)
     if (momentoFilter !== 'all')      result = result.filter(p => p.momento === momentoFilter)
-    else                              result = result.filter(p => p.momento !== 'churn')
+    else if (filter !== 'churn')      result = result.filter(p => p.momento !== 'churn')
     return result
   })()
 
@@ -856,7 +818,8 @@ export default function Dashboard() {
 
   // Counts for sidebar nav
   const counts = {
-    all:        baseProjects.length,
+    all:        baseProjects.filter(p => p.momento !== 'churn').length,
+    churn:      baseProjects.filter(p => p.momento === 'churn').length,
     onboarding: baseProjects.filter(p => p.status === 'onboarding').length,
     active:     baseProjects.filter(p => p.status === 'active').length,
     members:    Object.fromEntries(
@@ -876,33 +839,43 @@ export default function Dashboard() {
   // Derive page title from filter
   const pageTitle = (() => {
     if (filter === 'all')        return 'Clientes'
+    if (filter === 'churn')      return 'Churn'
     if (filter === 'onboarding') return 'Em Onboarding'
     if (filter === 'active')     return 'Perfis Ativos'
     const member = teamMembers.find(m => String(m.id) === String(filter))
     return member ? `Clientes de ${member.name.split(' ')[0]}` : 'Clientes'
   })()
 
+  function riskCounts(list) {
+    return {
+      em_risco: list.filter(p => p.riskLevel === 'em_risco').length,
+      neutro:   list.filter(p => p.riskLevel === 'neutro').length,
+      saudavel: list.filter(p => p.riskLevel === 'saudavel').length,
+      vazio:    list.filter(p => !p.riskLevel).length,
+    }
+  }
+
+  const MOMENTO_CARDS = [
+    { value: 'onboarding',      label: 'Em Onboarding',   icon: <Clock    className="w-5 h-5" />, color: 'text-orange-400', bg: 'bg-orange-400/10' },
+    { value: 'voo_de_cruzeiro', label: 'Voo de Cruzeiro', icon: <Cloud    className="w-5 h-5" />, color: 'text-rl-cyan',    bg: 'bg-rl-cyan/10'    },
+    { value: 'aceleracao',      label: 'Aceleração',      icon: <Zap      className="w-5 h-5" />, color: 'text-rl-green',   bg: 'bg-rl-green/10'   },
+    { value: null,              label: 'Sem Momento',     icon: <Layers   className="w-5 h-5" />, color: 'text-rl-muted',   bg: 'bg-rl-muted/10'   },
+  ]
+
   const stats = [
-    {
-      label: 'Em Onboarding',
-      value: counts.onboarding,
-      icon: <Clock className="w-5 h-5" />,
-      color: 'text-rl-cyan',
-      bg: 'bg-rl-cyan/10',
-    },
-    {
-      label: 'Clientes Ativos',
-      value: counts.active,
-      icon: <CheckCircle2 className="w-5 h-5" />,
-      color: 'text-rl-green',
-      bg: 'bg-rl-green/10',
-    },
+    ...MOMENTO_CARDS.map(m => {
+      const group = baseProjects.filter(p =>
+        m.value === null ? (!p.momento || p.momento === '') : p.momento === m.value
+      )
+      return { ...m, count: group.length, risks: riskCounts(group) }
+    }),
     {
       label: 'Total de Clientes',
-      value: baseProjects.length,
-      icon: <BarChart3 className="w-5 h-5" />,
+      count: baseProjects.filter(p => p.momento !== 'churn').length,
+      icon:  <BarChart3 className="w-5 h-5" />,
       color: 'text-rl-purple',
-      bg: 'bg-rl-purple/10',
+      bg:    'bg-rl-purple/10',
+      risks: riskCounts(baseProjects.filter(p => p.momento !== 'churn')),
     },
   ]
 
@@ -944,9 +917,15 @@ export default function Dashboard() {
           {/* Welcome */}
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 animate-slide-up">
             <div>
-              <h1 className="text-2xl font-bold text-rl-text">
-                Olá, {user.name.split(' ')[0]} 👋
-              </h1>
+              <div className="flex items-center gap-2.5 flex-wrap">
+                <h1 className="text-2xl font-bold text-rl-text">
+                  Olá, {user.name.split(' ')[0]} 👋
+                </h1>
+                <span className="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full bg-rl-purple/10 text-rl-purple border border-rl-purple/20">
+                  <Eye className="w-3 h-3" />
+                  {isAdmin ? 'Visão Admin' : 'Visão Geral'}
+                </span>
+              </div>
               <p className="text-rl-muted mt-1 text-sm">
                 Bem-vindo ao Revenue Lab Internal
               </p>
@@ -960,26 +939,60 @@ export default function Dashboard() {
             </button>
           </div>
 
-          {/* Workspace badge */}
-          <div
-            className="flex items-center gap-2 animate-slide-up"
-            style={{ animationDelay: '0.03s' }}
-          >
-            <Eye className="w-3.5 h-3.5 text-rl-purple" />
-            <p className="text-xs text-rl-purple font-medium">
-              {isAdmin ? 'Visão Admin' : 'Visão Geral'} — {projects.length} projeto{projects.length !== 1 ? 's' : ''} no workspace
-            </p>
-          </div>
-
           {/* Stats */}
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 animate-slide-up" style={{ animationDelay: '0.05s' }}>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 animate-slide-up" style={{ animationDelay: '0.05s' }}>
             {stats.map((s) => (
               <div key={s.label} className="glass-card p-5">
-                <div className={`w-10 h-10 rounded-xl ${s.bg} flex items-center justify-center mb-3 ${s.color}`}>
-                  {s.icon}
+                <div className="flex items-start justify-between gap-2 mb-0">
+                  <div>
+                    <p className="text-2xl font-bold text-rl-text">{s.count}</p>
+                    <p className={`text-xs mt-0.5 ${s.count === 0 ? 'text-rl-muted/50' : 'text-rl-muted'}`}>{s.label}</p>
+                  </div>
+                  <div className={`w-9 h-9 rounded-xl ${s.bg} flex items-center justify-center shrink-0 ${s.color}`}>
+                    {s.icon}
+                  </div>
                 </div>
-                <p className="text-2xl font-bold text-rl-text">{s.value}</p>
-                <p className="text-rl-muted text-xs mt-0.5">{s.label}</p>
+
+                {s.risks && (s.risks.em_risco > 0 || s.risks.neutro > 0 || s.risks.saudavel > 0 || s.risks.vazio > 0) && (
+                  <div className="mt-3 pt-3 border-t border-rl-border space-y-1.5">
+                    {s.risks.em_risco > 0 && (
+                      <div className="flex items-center justify-between text-[11px]">
+                        <div className="flex items-center gap-1.5 text-rl-muted">
+                          <span className="w-1.5 h-1.5 rounded-full bg-red-400 shrink-0" />
+                          Em Risco
+                        </div>
+                        <span className="font-semibold text-red-400">{s.risks.em_risco}</span>
+                      </div>
+                    )}
+                    {s.risks.neutro > 0 && (
+                      <div className="flex items-center justify-between text-[11px]">
+                        <div className="flex items-center gap-1.5 text-rl-muted">
+                          <span className="w-1.5 h-1.5 rounded-full bg-rl-gold shrink-0" />
+                          Neutro
+                        </div>
+                        <span className="font-semibold text-rl-gold">{s.risks.neutro}</span>
+                      </div>
+                    )}
+                    {s.risks.saudavel > 0 && (
+                      <div className="flex items-center justify-between text-[11px]">
+                        <div className="flex items-center gap-1.5 text-rl-muted">
+                          <span className="w-1.5 h-1.5 rounded-full bg-rl-green shrink-0" />
+                          Saudável
+                        </div>
+                        <span className="font-semibold text-rl-green">{s.risks.saudavel}</span>
+                      </div>
+                    )}
+                    {s.risks.vazio > 0 && (
+                      <div className="flex items-center justify-between text-[11px]">
+                        <div className="flex items-center gap-1.5 text-rl-muted">
+                          <span className="w-1.5 h-1.5 rounded-full bg-rl-muted/40 shrink-0" />
+                          Sem risco
+                        </div>
+                        <span className="font-semibold text-rl-muted">{s.risks.vazio}</span>
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             ))}
           </div>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useApp } from '../context/AppContext'
-import { Eye, EyeOff, Zap, Lock, Mail } from 'lucide-react'
+import { supabase } from '../lib/supabase'
+import { Eye, EyeOff, Zap, Lock, Mail, CheckCircle2 } from 'lucide-react'
 
 export default function Login() {
   const { login, loginWithGoogle, isSupabaseReady, authError } = useApp()
@@ -14,6 +15,24 @@ export default function Login() {
   const [loading, setLoading] = useState(false)
   const [loadingGoogle, setLoadingGoogle] = useState(false)
   const [shake, setShake] = useState(false)
+
+  const [forgotMode, setForgotMode]     = useState(false)
+  const [forgotEmail, setForgotEmail]   = useState('')
+  const [forgotSent, setForgotSent]     = useState(false)
+  const [forgotLoading, setForgotLoading] = useState(false)
+  const [forgotError, setForgotError]   = useState('')
+
+  async function handleForgotPassword(e) {
+    e.preventDefault()
+    setForgotLoading(true)
+    setForgotError('')
+    const { error } = await supabase.auth.resetPasswordForEmail(forgotEmail, {
+      redirectTo: `${window.location.origin}/reset-password`,
+    })
+    if (error) setForgotError(error.message)
+    else setForgotSent(true)
+    setForgotLoading(false)
+  }
 
   async function handleSubmit(e) {
     e.preventDefault()
@@ -67,112 +86,187 @@ export default function Login() {
 
         {/* Card */}
         <div className="glass-card p-8">
-          <h2 className="text-lg font-semibold text-rl-text mb-1">Bem-vindo de volta</h2>
-          <p className="text-rl-muted text-sm mb-6">Entre com suas credenciais para acessar o sistema.</p>
-
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {/* Email */}
-            <div>
-              <label className="label-field">E-mail</label>
-              <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-rl-muted" />
-                <input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="seu@revenuelab.com"
-                  className="input-field pl-10"
-                  required
-                />
-              </div>
-            </div>
-
-            {/* Password */}
-            <div>
-              <label className="label-field">Senha</label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-rl-muted" />
-                <input
-                  type={showPass ? 'text' : 'password'}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="••••••••"
-                  className="input-field pl-10 pr-10"
-                  required
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPass(!showPass)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-rl-muted hover:text-rl-subtle transition-colors"
-                >
-                  {showPass ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+          {forgotMode ? (
+            /* ── Esqueci minha senha ── */
+            forgotSent ? (
+              <div className="flex flex-col items-center gap-4 py-4 text-center">
+                <CheckCircle2 className="w-12 h-12 text-rl-green" />
+                <p className="text-rl-text font-semibold">E-mail enviado!</p>
+                <p className="text-rl-muted text-sm">Verifique sua caixa de entrada e clique no link para redefinir sua senha.</p>
+                <button onClick={() => { setForgotMode(false); setForgotSent(false); setForgotEmail('') }} className="mt-2 text-sm text-rl-purple hover:underline">
+                  Voltar ao login
                 </button>
               </div>
-            </div>
+            ) : (
+              <>
+                <h2 className="text-lg font-semibold text-rl-text mb-1">Esqueci minha senha</h2>
+                <p className="text-rl-muted text-sm mb-6">Informe seu e-mail e enviaremos um link para redefinir a senha.</p>
 
-            {/* Error */}
-            {(error || authError) && (
-              <div className="flex items-center gap-2 bg-red-500/10 border border-red-500/30 rounded-xl px-4 py-3 text-red-400 text-sm animate-fade-in">
-                <span className="w-4 h-4 shrink-0">⚠</span>
-                {authError || error}
-              </div>
-            )}
+                <form onSubmit={handleForgotPassword} className="space-y-4">
+                  <div>
+                    <label className="label-field">E-mail</label>
+                    <div className="relative">
+                      <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-rl-muted" />
+                      <input
+                        type="email"
+                        value={forgotEmail}
+                        onChange={e => setForgotEmail(e.target.value)}
+                        placeholder="seu@revenuelab.com"
+                        className="input-field pl-10"
+                        required
+                        autoFocus
+                      />
+                    </div>
+                  </div>
 
-            {/* Submit */}
-            <button
-              type="submit"
-              disabled={loading || loadingGoogle}
-              className="btn-primary w-full flex items-center justify-center gap-2 mt-2"
-            >
-              {loading ? (
-                <>
-                  <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                  Entrando...
-                </>
-              ) : (
-                <>
-                  <Zap className="w-4 h-4" />
-                  Entrar no Sistema
-                </>
-              )}
-            </button>
-          </form>
+                  {forgotError && (
+                    <div className="flex items-center gap-2 bg-red-500/10 border border-red-500/30 rounded-xl px-4 py-3 text-red-400 text-sm">
+                      <span className="shrink-0">⚠</span>
+                      {forgotError}
+                    </div>
+                  )}
 
-          {/* Google login */}
-          {isSupabaseReady && (
-            <div className="mt-4">
-              <div className="relative flex items-center gap-3 my-4">
-                <div className="flex-1 h-px bg-rl-border" />
-                <span className="text-rl-muted text-xs">ou</span>
-                <div className="flex-1 h-px bg-rl-border" />
-              </div>
-              <button
-                type="button"
-                onClick={handleGoogle}
-                disabled={loading || loadingGoogle}
-                className="w-full flex items-center justify-center gap-3 px-4 py-2.5 rounded-xl border border-rl-border bg-rl-surface hover:bg-rl-surface/80 text-rl-text text-sm font-medium transition-colors disabled:opacity-50"
-              >
-                {loadingGoogle ? (
-                  <span className="w-4 h-4 border-2 border-rl-muted/30 border-t-rl-muted rounded-full animate-spin" />
-                ) : (
-                  <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24">
-                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/>
-                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                  </svg>
+                  <button
+                    type="submit"
+                    disabled={forgotLoading}
+                    className="btn-primary w-full flex items-center justify-center gap-2 mt-2"
+                  >
+                    {forgotLoading ? (
+                      <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    ) : (
+                      <Mail className="w-4 h-4" />
+                    )}
+                    Enviar link de redefinição
+                  </button>
+                </form>
+
+                <div className="mt-5 text-center">
+                  <button onClick={() => setForgotMode(false)} className="text-sm text-rl-muted hover:text-rl-text transition-colors">
+                    ← Voltar ao login
+                  </button>
+                </div>
+              </>
+            )
+          ) : (
+            /* ── Login normal ── */
+            <>
+              <h2 className="text-lg font-semibold text-rl-text mb-1">Bem-vindo de volta</h2>
+              <p className="text-rl-muted text-sm mb-6">Entre com suas credenciais para acessar o sistema.</p>
+
+              <form onSubmit={handleSubmit} className="space-y-4">
+                {/* Email */}
+                <div>
+                  <label className="label-field">E-mail</label>
+                  <div className="relative">
+                    <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-rl-muted" />
+                    <input
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      placeholder="seu@revenuelab.com"
+                      className="input-field pl-10"
+                      required
+                    />
+                  </div>
+                </div>
+
+                {/* Password */}
+                <div>
+                  <div className="flex items-center justify-between mb-1.5">
+                    <label className="label-field !mb-0">Senha</label>
+                    <button
+                      type="button"
+                      onClick={() => setForgotMode(true)}
+                      className="text-xs text-rl-muted hover:text-rl-purple transition-colors"
+                    >
+                      Esqueci minha senha
+                    </button>
+                  </div>
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-rl-muted" />
+                    <input
+                      type={showPass ? 'text' : 'password'}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      placeholder="••••••••"
+                      className="input-field pl-10 pr-10"
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPass(!showPass)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-rl-muted hover:text-rl-subtle transition-colors"
+                    >
+                      {showPass ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Error */}
+                {(error || authError) && (
+                  <div className="flex items-center gap-2 bg-red-500/10 border border-red-500/30 rounded-xl px-4 py-3 text-red-400 text-sm animate-fade-in">
+                    <span className="w-4 h-4 shrink-0">⚠</span>
+                    {authError || error}
+                  </div>
                 )}
-                Entrar com Google
-              </button>
-            </div>
-          )}
 
-          {/* Footer */}
-          <div className="mt-6 pt-5 border-t border-rl-border text-center">
-            <p className="text-rl-muted text-xs">
-              Credenciais de acesso fornecidas pelo administrador.
-            </p>
-          </div>
+                {/* Submit */}
+                <button
+                  type="submit"
+                  disabled={loading || loadingGoogle}
+                  className="btn-primary w-full flex items-center justify-center gap-2 mt-2"
+                >
+                  {loading ? (
+                    <>
+                      <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                      Entrando...
+                    </>
+                  ) : (
+                    <>
+                      <Zap className="w-4 h-4" />
+                      Entrar no Sistema
+                    </>
+                  )}
+                </button>
+              </form>
+
+              {/* Google login */}
+              {isSupabaseReady && (
+                <div className="mt-4">
+                  <div className="relative flex items-center gap-3 my-4">
+                    <div className="flex-1 h-px bg-rl-border" />
+                    <span className="text-rl-muted text-xs">ou</span>
+                    <div className="flex-1 h-px bg-rl-border" />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleGoogle}
+                    disabled={loading || loadingGoogle}
+                    className="w-full flex items-center justify-center gap-3 px-4 py-2.5 rounded-xl border border-rl-border bg-rl-surface hover:bg-rl-surface/80 text-rl-text text-sm font-medium transition-colors disabled:opacity-50"
+                  >
+                    {loadingGoogle ? (
+                      <span className="w-4 h-4 border-2 border-rl-muted/30 border-t-rl-muted rounded-full animate-spin" />
+                    ) : (
+                      <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24">
+                        <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                        <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                        <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/>
+                        <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                      </svg>
+                    )}
+                    Entrar com Google
+                  </button>
+                </div>
+              )}
+
+              {/* Footer */}
+              <div className="mt-6 pt-5 border-t border-rl-border text-center">
+                <p className="text-rl-muted text-xs">
+                  Credenciais de acesso fornecidas pelo administrador.
+                </p>
+              </div>
+            </>
+          )}
         </div>
 
         <p className="text-center text-rl-muted/40 text-xs mt-6">

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,0 +1,145 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { supabase } from '../lib/supabase'
+import { Eye, EyeOff, Zap, Lock, CheckCircle2 } from 'lucide-react'
+
+export default function ResetPassword() {
+  const navigate = useNavigate()
+  const [ready, setReady]       = useState(false)
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm]   = useState('')
+  const [showPass, setShowPass] = useState(false)
+  const [loading, setLoading]   = useState(false)
+  const [error, setError]       = useState('')
+  const [done, setDone]         = useState(false)
+
+  useEffect(() => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'PASSWORD_RECOVERY') setReady(true)
+    })
+    return () => subscription.unsubscribe()
+  }, [])
+
+  const mismatch = confirm.length > 0 && password !== confirm
+  const valid    = password.length >= 6 && password === confirm
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    if (!valid) return
+    setLoading(true)
+    setError('')
+    const { error: err } = await supabase.auth.updateUser({ password })
+    if (err) {
+      setError(err.message)
+    } else {
+      setDone(true)
+      await supabase.auth.signOut()
+      setTimeout(() => navigate('/login'), 2500)
+    }
+    setLoading(false)
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-dark flex items-center justify-center px-4 relative overflow-hidden">
+      <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-rl-purple/10 rounded-full blur-3xl pointer-events-none" />
+      <div className="absolute bottom-1/4 right-1/4 w-80 h-80 bg-rl-blue/10 rounded-full blur-3xl pointer-events-none" />
+
+      <div className="relative z-10 w-full max-w-md animate-slide-up">
+        {/* Logo */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-rl mb-4 shadow-glow animate-float">
+            <Zap className="w-8 h-8 text-white" />
+          </div>
+          <h1 className="text-2xl font-bold text-rl-text">Revenue Lab</h1>
+          <p className="text-rl-muted text-sm mt-1">Redefinição de Senha</p>
+        </div>
+
+        <div className="glass-card p-8">
+          {done ? (
+            <div className="flex flex-col items-center gap-4 py-4 text-center">
+              <CheckCircle2 className="w-12 h-12 text-rl-green" />
+              <p className="text-rl-text font-semibold">Senha atualizada com sucesso!</p>
+              <p className="text-rl-muted text-sm">Redirecionando para o login...</p>
+            </div>
+          ) : !ready ? (
+            <div className="flex flex-col items-center gap-3 py-8">
+              <span className="w-8 h-8 border-2 border-rl-purple/30 border-t-rl-purple rounded-full animate-spin" />
+              <p className="text-rl-muted text-sm">Verificando link de redefinição...</p>
+            </div>
+          ) : (
+            <>
+              <h2 className="text-lg font-semibold text-rl-text mb-1">Nova senha</h2>
+              <p className="text-rl-muted text-sm mb-6">Escolha uma nova senha para sua conta.</p>
+
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <label htmlFor="rp-password" className="label-field">Nova senha</label>
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-rl-muted" />
+                    <input
+                      id="rp-password"
+                      type={showPass ? 'text' : 'password'}
+                      value={password}
+                      onChange={e => setPassword(e.target.value)}
+                      placeholder="Mínimo 6 caracteres"
+                      className="input-field pl-10 pr-10"
+                      required
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPass(v => !v)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-rl-muted hover:text-rl-subtle transition-colors"
+                    >
+                      {showPass ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </button>
+                  </div>
+                  {password.length > 0 && password.length < 6 && (
+                    <p className="text-xs text-rl-red mt-1">Mínimo 6 caracteres</p>
+                  )}
+                </div>
+
+                <div>
+                  <label htmlFor="rp-confirm" className="label-field">Confirmar senha</label>
+                  <div className="relative">
+                    <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-rl-muted" />
+                    <input
+                      id="rp-confirm"
+                      type={showPass ? 'text' : 'password'}
+                      value={confirm}
+                      onChange={e => setConfirm(e.target.value)}
+                      placeholder="Repita a senha"
+                      className="input-field pl-10"
+                      required
+                    />
+                  </div>
+                  {mismatch && <p className="text-xs text-rl-red mt-1">As senhas não coincidem</p>}
+                </div>
+
+                {error && (
+                  <div className="flex items-center gap-2 bg-red-500/10 border border-red-500/30 rounded-xl px-4 py-3 text-red-400 text-sm">
+                    <span className="shrink-0">⚠</span>
+                    {error}
+                  </div>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={!valid || loading}
+                  className="btn-primary w-full flex items-center justify-center gap-2 mt-2 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {loading ? (
+                    <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  ) : (
+                    <Lock className="w-4 h-4" />
+                  )}
+                  Definir nova senha
+                </button>
+              </form>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -11,7 +11,7 @@ import AppSidebar from '../components/AppSidebar'
 import {
   Users, Plus, Pencil, UserX, UserCheck,
   X, AlertTriangle, Loader2, Menu,
-  ShieldCheck, User, Users2, Trash2,
+  ShieldCheck, User, Users2, Trash2, KeyRound, Eye, EyeOff,
 } from 'lucide-react'
 
 async function callAdminAPI(action, payload) {
@@ -33,6 +33,83 @@ async function callAdminAPI(action, payload) {
 }
 
 // ── Modais ─────────────────────────────────────────────────────────────────
+
+function PasswordModal({ user, onSave, onClose, saving }) {
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm]   = useState('')
+  const [showPass, setShowPass] = useState(false)
+
+  const mismatch = confirm.length > 0 && password !== confirm
+  const valid    = password.length >= 6 && password === confirm
+
+  return (
+    <Modal onClose={onClose} maxWidth="sm">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-2">
+          <KeyRound className="w-5 h-5 text-rl-purple" />
+          <h2 className="text-base font-bold text-rl-text">Redefinir senha</h2>
+        </div>
+        <button onClick={onClose} aria-label="Fechar" className="p-1.5 rounded-lg text-rl-muted hover:text-rl-text hover:bg-rl-surface transition-all">
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      <div className="rounded-xl bg-rl-surface border border-rl-border px-4 py-3 mb-5">
+        <p className="text-[11px] text-rl-muted mb-0.5">Usuário</p>
+        <p className="text-sm font-bold text-rl-text">{user.name}</p>
+        <p className="text-xs text-rl-muted mt-0.5">{user.email}</p>
+      </div>
+
+      <div className="space-y-4 mb-6">
+        <div>
+          <label htmlFor="pwd-new" className="block text-xs font-semibold text-rl-text mb-1.5">Nova senha</label>
+          <div className="relative">
+            <input
+              id="pwd-new"
+              type={showPass ? 'text' : 'password'}
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              placeholder="Mínimo 6 caracteres"
+              className="input-field w-full pr-10"
+              autoFocus
+            />
+            <button type="button" onClick={() => setShowPass(v => !v)} className="absolute right-3 top-1/2 -translate-y-1/2 text-rl-muted hover:text-rl-subtle transition-colors">
+              {showPass ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </button>
+          </div>
+          {password.length > 0 && password.length < 6 && (
+            <p className="text-xs text-rl-red mt-1">Mínimo 6 caracteres</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="pwd-confirm" className="block text-xs font-semibold text-rl-text mb-1.5">Confirmar senha</label>
+          <input
+            id="pwd-confirm"
+            type={showPass ? 'text' : 'password'}
+            value={confirm}
+            onChange={e => setConfirm(e.target.value)}
+            placeholder="Repita a senha"
+            className="input-field w-full"
+          />
+          {mismatch && <p className="text-xs text-rl-red mt-1">As senhas não coincidem</p>}
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <button onClick={onClose} className="flex-1 btn-ghost" disabled={saving}>Cancelar</button>
+        <button
+          onClick={() => onSave(password)}
+          disabled={!valid || saving}
+          className="flex-1 btn-primary disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+        >
+          {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <KeyRound className="w-4 h-4" />}
+          Salvar senha
+        </button>
+      </div>
+    </Modal>
+  )
+}
 
 function UserFormModal({ title, initial, onSave, onClose, saving }) {
   const [form, setForm] = useState({
@@ -380,6 +457,9 @@ export default function UserManagement() {
   const [saving, setSaving] = useState(false)
   const { toast, showToast } = useToast()
 
+  // Password reset state
+  const [passwordTarget, setPasswordTarget] = useState(null)
+
   // Squad state
   const [showCreateSquad, setShowCreateSquad] = useState(false)
   const [editSquadTarget, setEditSquadTarget] = useState(null)
@@ -465,6 +545,18 @@ export default function UserManagement() {
     member: 'text-rl-blue   bg-rl-blue/10   border-rl-blue/30',
   }
   const ROLE_LABEL = { admin: 'Admin', member: 'Membro' }
+
+  async function handleResetPassword(password) {
+    setSaving(true)
+    const result = await callAdminAPI('reset_password', { userId: passwordTarget.id, password })
+    if (result.error) {
+      showToast(result.error, 'error')
+    } else {
+      showToast(`Senha de ${passwordTarget.name} redefinida.`)
+      setPasswordTarget(null)
+    }
+    setSaving(false)
+  }
 
   async function handleCreateSquad(form) {
     setSavingSquad(true)
@@ -653,6 +745,14 @@ export default function UserManagement() {
                           >
                             <Pencil className="w-3.5 h-3.5" />
                           </button>
+                          <button
+                            onClick={() => setPasswordTarget(u)}
+                            aria-label="Redefinir senha"
+                            className="p-1.5 rounded-lg text-rl-muted hover:text-rl-cyan hover:bg-rl-cyan/10 transition-all"
+                            title="Redefinir senha"
+                          >
+                            <KeyRound className="w-3.5 h-3.5" />
+                          </button>
                           {u.id !== currentUser?.id && (
                             <button
                               onClick={() => setToggleTarget(u)}
@@ -780,6 +880,16 @@ export default function UserManagement() {
           user={toggleTarget}
           onConfirm={handleToggle}
           onClose={() => setToggleTarget(null)}
+          saving={saving}
+        />
+      )}
+
+      {/* Modal — Redefinir senha */}
+      {passwordTarget && (
+        <PasswordModal
+          user={passwordTarget}
+          onSave={handleResetPassword}
+          onClose={() => setPasswordTarget(null)}
           saving={saving}
         />
       )}


### PR DESCRIPTION
## Summary

- **Password reset (2 fluxos)**: admin redefine senha diretamente via modal; usuário recebe link por email via `/reset-password` (evento `PASSWORD_RECOVERY`)
- **Dashboard stats**: cards de Momento (Pré-lançamento, Lançamento, Escala, Manutenção) com breakdown de risco por card, incluindo "Sem risco"; churn excluído do total
- **Sidebar nav**: estilo ativo/hover padronizado (purple scheme); filtros de status removidos; "Churn" como rota dedicada; Playbook com ícone ExternalLink; Banco de Anúncios passa a exibir a sidebar lateral
- **BancoMídia Storage**: uploads de fotos/vídeos/logo migrados de base64-JSONB para Supabase Storage (buckets `brand-media` e `brand-logos`); backward compat com itens legados mantida

## Test plan

- [ ] Admin redefine senha de outro usuário via ícone de chave em UserManagement
- [ ] Usuário clica "Esqueci minha senha" → recebe email → redireciona para `/reset-password` → senha atualizada
- [ ] Cards de stats da Dashboard exibem contagens por Momento com breakdown de riscos
- [ ] Filtro "Churn" na sidebar lista apenas projetos com `momento === 'churn'`
- [ ] Playbook abre em nova aba; Banco de Anúncios abre com sidebar; apenas um item ativo por vez
- [ ] Upload de foto/vídeo/logo no BancoMídia grava no Storage (verificar no Supabase Dashboard)
- [ ] Itens legados (base64) continuam renderizando normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)