### PR TITLE
Adicionar botão Tarefas na sidebar

### DIFF
--- a/src/components/AppSidebar.jsx
+++ b/src/components/AppSidebar.jsx
@@ -4,12 +4,13 @@ import { useApp } from '../context/AppContext'
 import {
   Zap, Plus, Layers, TrendingDown,
   LogOut, Cloud, CloudOff, Loader2,
-  X, UserCog, BookOpen, Library, ExternalLink, GitFork,
+  X, UserCog, BookOpen, Library, ExternalLink, GitFork, CheckSquare,
 } from 'lucide-react'
 
 const NAV_ITEMS = [
   { id: 'all',      label: 'Clientes',          Icon: Layers,        type: 'filter'   },
   { id: 'churn',    label: 'Churn',             Icon: TrendingDown,  type: 'filter'   },
+  { id: 'tarefas',  label: 'Tarefas',           Icon: CheckSquare,   type: 'action'   },
 ]
 
 const NAV_LINKS = [
@@ -62,13 +63,14 @@ function SidebarContent({
 
       {/* ── Navigation ──────────────────────────────────── */}
       <nav className="space-y-0.5 mb-2">
-        {NAV_ITEMS.map(({ id, label, Icon }) => {
-          const count = counts?.[id] ?? 0
-          const active = filter === id && location.pathname === '/'
+        {NAV_ITEMS.map(({ id, label, Icon, type }) => {
+          const isFilter = type === 'filter'
+          const count = isFilter ? (counts?.[id] ?? 0) : 0
+          const active = isFilter && filter === id && location.pathname === '/'
           return (
             <button
               key={id}
-              onClick={() => onNav(id)}
+              onClick={isFilter ? () => onNav(id) : undefined}
               className={`w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150 group border ${
                 active
                   ? 'bg-rl-purple/15 text-rl-purple border-rl-purple/25'


### PR DESCRIPTION
## Resumo
- Adiciona o botão "Tarefas" na sidebar (`AppSidebar.jsx`), abaixo de "Clientes" e "Churn", usando o ícone `CheckSquare` do lucide-react.
- Por enquanto é um placeholder sem ação — o `onClick` é `undefined` (o destino pode ser definido depois).

## Test plan
- [ ] Abrir a aplicação e verificar que o item "Tarefas" aparece na sidebar lateral
- [ ] Confirmar que o hover funciona normalmente
- [ ] Confirmar que clicar no botão não dispara nenhuma navegação ou mudança de filtro

https://claude.ai/code/session_0186K3wpfu8ERj6sg8DZRLfH

---
_Generated by [Claude Code](https://claude.ai/code/session_0186K3wpfu8ERj6sg8DZRLfH)_